### PR TITLE
Rename `outcome` function with `output`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v1.0.2 - dev
 
 - Remove StaticArrays as a dependency and add as an extension.
-- Add `Generaldyne` type with corresponding `outcome` function.
+- Add `Generaldyne` type with corresponding `output` function.
 
 ## v1.0.1 - 2024-10-16
 

--- a/src/Gabs.jl
+++ b/src/Gabs.jl
@@ -11,7 +11,7 @@ export
     # types
     GaussianState, GaussianUnitary, GaussianChannel, Generaldyne,
     # operations
-    tensor, ⊗, apply!, ptrace, outcome,
+    tensor, ⊗, apply!, ptrace, output,
     # predefined Gaussian states
     vacuumstate, thermalstate, coherentstate, squeezedstate, eprstate,
     # predefined Gaussian channels

--- a/src/measurements.jl
+++ b/src/measurements.jl
@@ -9,7 +9,7 @@ struct Generaldyne{I} <: AbstractGeneralDyne
         return new{I}(sys, cond, ind)
     end
 end
-function outcome(meas::Generaldyne)
+function output(meas::Generaldyne)
     sys, cond, ind = meas.system, meas.conditional, meas.indices
     # partition mean and covar into subsystems A and B
     meanA, meanB = _part_mean(sys, ind)

--- a/test/test_measurements.jl
+++ b/test/test_measurements.jl
@@ -6,20 +6,20 @@
         vac = vacuumstate()
         vacs = vac ⊗ vac ⊗ vac ⊗ vac
         gd1 = Generaldyne(vacs, vac ⊗ vac, [2, 4])
-        out1 = outcome(gd1)
+        out1 = output(gd1)
         @test isequal(out1, vac ⊗ vac)
 
         coh = coherentstate(1.0+im)
         cohs = coh ⊗ vac ⊗ coh ⊗ vac
         epr = eprstate(1.0, 3.0)
         gd2 = Generaldyne(cohs, epr, [1, 4])
-        out2 = outcome(gd2)
+        out2 = output(gd2)
         @test isequal(out2, vac ⊗ coh)
 
         state = GaussianState(Vector{Float64}(collect(1:4)), Matrix{Float64}(reshape(collect(1:16), (4,4))))
         meas = GaussianState(Vector{Float64}(collect(1:2)), Matrix{Float64}(reshape(collect(1:4), (2,2))))
         gd3 = Generaldyne(state, meas, [2])
-        out3 = outcome(gd3)
+        out3 = output(gd3)
         xA, xB = [1.0, 2.0], [3.0, 4.0]
         VA, VB, VAB = [1.0 5.0; 2.0 6.0], [11.0 15.0; 12.0 16.0], [9.0 13.0; 10.0 14.0]
         out3_mean = xA .+ VAB*((inv(VB .+ meas.covar))*(meas.mean .- xB))
@@ -29,7 +29,7 @@
         sstatic = vacuumstate(SVector{2}, SMatrix{2,2})
         statestatic = sstatic ⊗ sstatic ⊗ sstatic ⊗ sstatic
         gdstatic = Generaldyne(statestatic, sstatic, [2])
-        outstatic = outcome(gdstatic)
+        outstatic = output(gdstatic)
         @test isequal(outstatic, sstatic ⊗ sstatic ⊗ sstatic)
     end
 end


### PR DESCRIPTION
Per Ref. https://journals.aps.org/rmp/pdf/10.1103/RevModPhys.84.621, `output` is a more standard way of referring to the mapping of subsystem A by a general dyne measurement. `outcome` can be misleading, as it often refers to the measurement conditional state.