### PR TITLE
add functions to create random instances of Gabs types

### DIFF
--- a/src/Gabs.jl
+++ b/src/Gabs.jl
@@ -13,10 +13,10 @@ export
     # operations
     tensor, ⊗, apply!, ptrace, output,
     # predefined Gaussian states
-    vacuumstate, thermalstate, coherentstate, squeezedstate, eprstate,
+    vacuumstate, thermalstate, coherentstate, squeezedstate, eprstate, randstate,
     # predefined Gaussian channels
     displace, squeeze, twosqueeze, phaseshift, beamsplitter,
-    attenuator, amplifier,
+    attenuator, amplifier, randchannel,
     # wigner functions
     wigner, wignerchar,
     # symplectic form
@@ -33,6 +33,8 @@ include("states.jl")
 include("unitaries.jl")
 
 include("channels.jl")
+
+include("randoms.jl")
 
 include("measurements.jl")
 

--- a/src/randoms.jl
+++ b/src/randoms.jl
@@ -1,0 +1,35 @@
+"""
+    randstate([Tm=Vector{Float64}, Tc=Matrix{Float64},] nmodes<:Int)
+
+Calculate a random Gaussian state.
+"""
+function randstate(::Type{Tm}, ::Type{Tc}, nmodes::N) where {Tm,Tc,N<:Int}
+    mean = randn(2*nmodes)
+    covar = randn(2*nmodes, 2*nmodes)
+    return GaussianState(Tm(mean), Tc(covar), nmodes)
+end
+randstate(::Type{T}, nmodes::N) where {T,N<:Int} = randstate(T,T,nmodes)
+function randstate(nmodes::N) where {N<:Int}
+    mean = randn(2*nmodes)
+    covar = randn(2*nmodes, 2*nmodes)
+    return GaussianState(mean, covar, nmodes)
+end
+
+"""
+    randchannel([Td=Vector{Float64}, Tt=Matrix{Float64},] nmodes<:Int)
+
+Calculate a random Gaussian channel.
+"""
+function randchannel(::Type{Td}, ::Type{Tt}, nmodes::N) where {Td,Tt,N<:Int}
+    disp = randn(2*nmodes)
+    transform = randn(2*nmodes, 2*nmodes)
+    noise = randn(2*nmodes, 2*nmodes)
+    return GaussianChannel(Td(disp), Tt(transform), Tt(noise), nmodes)
+end
+randchannel(::Type{T}, nmodes::N) where {T,N<:Int} = randchannel(T,T,nmodes)
+function randchannel(nmodes::N) where {N<:Int}
+    disp = randn(2*nmodes)
+    transform = randn(2*nmodes, 2*nmodes)
+    noise = randn(2*nmodes, 2*nmodes)
+    return GaussianChannel(disp, transform, noise, nmodes)
+end

--- a/test/test_randoms.jl
+++ b/test/test_randoms.jl
@@ -1,0 +1,22 @@
+@testitem "Measurements" begin
+    using Gabs
+    using StaticArrays
+
+    @testset "random types" begin
+        nmodes = rand(1:20)
+        rs = randstate(nmodes)
+        rc = randchannel(nmodes)
+        @test rc isa GaussianChannel
+        @test rc * rs isa GaussianState
+
+        rsfloat32 = randstate(AbstractArray{Float32}, nmodes)
+        rcfloat32 = randchannel(AbstractArray{Float32}, nmodes)
+        @test rcfloat32 isa GaussianChannel
+        @test rcfloat32 * rsfloat32 isa GaussianState
+
+        rsstatic = randstate(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, nmodes)
+        rcstatic = randchannel(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, nmodes)
+        @test rcstatic isa GaussianChannel
+        @test rcstatic * rsstatic isa GaussianState
+    end
+end


### PR DESCRIPTION
`randstate`  and `randchannel` creates a `GaussianState` and `GaussianChannel` object, respectively, wrapped around random arrays. In the future, I would like to find a straightforward way to create random symplectic matrices so that we can have a `randunitary` function to create random `GaussianUnitary` objects. It should also be noted that there is namespace overlap with QuantumOptics.jl (https://docs.qojulia.org/api/#QuantumOpticsBase.randstate). A PR to QuantumInterface.jl should be made to address this.