### PR TITLE
Ensure random generation of positive-definite matrices in `randstate` and `randchannel`

### DIFF
--- a/src/randoms.jl
+++ b/src/randoms.jl
@@ -5,13 +5,17 @@ Calculate a random Gaussian state.
 """
 function randstate(::Type{Tm}, ::Type{Tc}, nmodes::N) where {Tm,Tc,N<:Int}
     mean = randn(2*nmodes)
-    covar = randn(2*nmodes, 2*nmodes)
+    randmat = randn(2*nmodes, 2*nmodes)
+    # positive-definite condition
+    covar = randmat' * randmat
     return GaussianState(Tm(mean), Tc(covar), nmodes)
 end
 randstate(::Type{T}, nmodes::N) where {T,N<:Int} = randstate(T,T,nmodes)
 function randstate(nmodes::N) where {N<:Int}
     mean = randn(2*nmodes)
-    covar = randn(2*nmodes, 2*nmodes)
+    randmat = randn(2*nmodes, 2*nmodes)
+    # positive-definite condition
+    covar = randmat' * randmat
     return GaussianState(mean, covar, nmodes)
 end
 
@@ -23,13 +27,17 @@ Calculate a random Gaussian channel.
 function randchannel(::Type{Td}, ::Type{Tt}, nmodes::N) where {Td,Tt,N<:Int}
     disp = randn(2*nmodes)
     transform = randn(2*nmodes, 2*nmodes)
-    noise = randn(2*nmodes, 2*nmodes)
+    randmat = randn(2*nmodes, 2*nmodes)
+    # positive-definite condition
+    noise = randmat' * randmat
     return GaussianChannel(Td(disp), Tt(transform), Tt(noise), nmodes)
 end
 randchannel(::Type{T}, nmodes::N) where {T,N<:Int} = randchannel(T,T,nmodes)
 function randchannel(nmodes::N) where {N<:Int}
     disp = randn(2*nmodes)
     transform = randn(2*nmodes, 2*nmodes)
-    noise = randn(2*nmodes, 2*nmodes)
+    randmat = randn(2*nmodes, 2*nmodes)
+    # positive-definite condition
+    noise = randmat' * randmat
     return GaussianChannel(disp, transform, noise, nmodes)
 end


### PR DESCRIPTION
Per https://journals.aps.org/rmp/pdf/10.1103/RevModPhys.84.621, the covariance matrix of a Gaussian state must be positive-definite. Similarly, the noise matrix of a Gaussian CPTP must be positive-definite. This PR makes those changes.