### PR TITLE
Add symplectic representation feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # News
 
-## v1.1.1 - dev
+## v1.2.0 - dev
 
 - Add a benchmark suite as a part of the Github workflows.
+- **(breaking)** Require a `SymplecticBasis` subtype to be defined when creating a Gaussian object.
 
 ## v1.1.0 - 2024-11-18
 

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -16,8 +16,9 @@ for op in op_list
 end
 
 for nmodes in (2, 10, 50, 100, 200)
-    SUITE["operations"]["unitary product"][string(nmodes)] = @benchmarkable op * state setup=(op = randunitary($nmodes); state = randstate($nmodes))
-    SUITE["operations"]["channel product"][string(nmodes)] = @benchmarkable ch * state setup=(ch = randchannel($nmodes); state = randstate($nmodes))
-    SUITE["operations"]["tensor product"][string(nmodes)] = @benchmarkable state1 ⊗ state2 setup=(state1 = randstate($nmodes); state2 = randstate($nmodes))
-    SUITE["operations"]["partial trace"][string(nmodes)] = @benchmarkable ptrace(state, indices) setup=(state = randstate($nmodes); indices = collect(2:$nmodes))
+    basis = QuadPairBasis(nmodes)
+    SUITE["operations"]["unitary product"][string(nmodes)] = @benchmarkable op * state setup=(op = randunitary($basis); state = randstate($basis))
+    SUITE["operations"]["channel product"][string(nmodes)] = @benchmarkable ch * state setup=(ch = randchannel($basis); state = randstate($basis))
+    SUITE["operations"]["tensor product"][string(nmodes)] = @benchmarkable state1 ⊗ state2 setup=(state1 = randstate($basis); state2 = randstate($basis))
+    SUITE["operations"]["partial trace"][string(nmodes)] = @benchmarkable ptrace(state, indices) setup=(state = randstate($basis); indices = collect(2:$nmodes))
 end

--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -40,11 +40,11 @@ which can be typed in the Julia REPL as `\otimes<TAB>`. Take the following examp
 ```jldoctest
 julia> basis = QuadPairBasis(1);
 
-julia> coherentstate(basis, -1.0) ⊗ vacuumstate(basis) ⊗ squeezedstate(basis, 0.25, pi/4)
+julia> coherentstate(basis, -1.0+im) ⊗ vacuumstate(basis) ⊗ squeezedstate(basis, 0.25, pi/4)
 GaussianState for 3 modes in QuadPairBasis representation.
 mean: 6-element Vector{Float64}:
  -1.4142135623730951
-  0.0
+  1.4142135623730951
   0.0
   0.0
   0.0
@@ -58,9 +58,29 @@ covariance: 6×6 Matrix{Float64}:
  0.0  0.0  0.0  0.0  0.184235  0.748048
 ```
 
-Note that in the above example, we defined the symplectic basis of the Gaussian state to be `QuadPairBasis`,
-which determines the arrangement of our quadrature field operators to be pairwise: $\mathbf{\hat{x}} = (q_1, p_1, q_2, p_2, q_3, p_3)^{\text{T}}$. If we wanted the field operators to be ordered blockwise, i.e.,
-$\mathbf{\hat{x}} = (q_1, q_2, q_3, p_1, p_2, p_3)^{\text{T}}$ then we would call `QuadBlockBasis` instead.
+Note that in the above example, we defined the symplectic basis of the Gaussian state to be [`QuadPairBasis`](@ref), which determines the arrangement of our quadrature field operators to be pairwise: $\mathbf{\hat{x}} = (q_1, p_1, q_2, p_2, q_3, p_3)^{\text{T}}$. If we wanted the field operators to be ordered blockwise, i.e.,
+$\mathbf{\hat{x}} = (q_1, q_2, q_3, p_1, p_2, p_3)^{\text{T}}$ then we would call [`QuadBlockBasis`](@ref) instead:
+
+```julia
+julia> basis = QuadBlockBasis(1);
+
+julia> coherentstate(basis, -1.0+im) ⊗ vacuumstate(basis) ⊗ squeezedstate(basis, 0.25, pi/4)
+GaussianState for 3 modes in QuadBlockBasis representation.
+mean: 6-element Vector{Float64}:
+ -1.4142135623730951
+  0.0
+  0.0
+  1.4142135623730951
+  0.0
+  0.0
+covariance: 6×6 Matrix{Float64}:
+ 1.0  0.0  0.0       0.0  0.0  0.0
+ 0.0  1.0  0.0       0.0  0.0  0.0
+ 0.0  0.0  0.379578  0.0  0.0  0.184235
+ 0.0  0.0  0.0       1.0  0.0  0.0
+ 0.0  0.0  0.0       0.0  1.0  0.0
+ 0.0  0.0  0.184235  0.0  0.0  0.748048
+```
 
 ## Gaussian Operators
 

--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -58,6 +58,10 @@ covariance: 6×6 Matrix{Float64}:
  0.0  0.0  0.0  0.0  0.184235  0.748048
 ```
 
+Note that in the above example, we defined the symplectic basis of the Gaussian state to be `QuadPairBasis`,
+which determines the arrangement of our quadrature field operators to be pairwise: $\mathbf{\hat{x}} = (q_1, p_1, q_2, p_2, q_3, p_3)^{\text{T}}$. If we wanted the field operators to be ordered blockwise, i.e.,
+$\mathbf{\hat{x}} = (q_1, q_2, q_3, p_1, p_2, p_3)^{\text{T}}$ then we would call `QuadBlockBasis` instead.
+
 ## Gaussian Operators
 
 To transform Gaussian states into Gaussian states, we need Gaussian maps. There are various ways to construct Gaussian transformations, which we will discuss in this section.
@@ -76,16 +80,11 @@ an `N`-mode Gaussian bosonic system. As long as we have a displacement vector of
 !!! note
     A matrix $\mathbf{S}$ of size $2N\times 2N$ is symplectic when it satisfies the following relation:
 
-    $$\mathbf{S} \mathbf{\Omega} \mathbf{S}^{\text{T}} = \mathbf{\Omega}, \qquad \mathbf{\Omega} = \bigoplus_{i=1}^{N} \begin{pmatrix} 0 & -1 \\ -1 & 0 \end{pmatrix}.$$
+    $$\mathbf{S} \mathbf{\Omega} \mathbf{S}^{\text{T}} = \mathbf{\Omega}.
 
     In this library, we define symplectic matrices with respect to $\Omega$, the *symplectic form*, which satisfies the canonical
     commutation relation $[\hat{x}_i, \hat{x}_j] = 2i\Omega_{ij}$, where $\hat{x}_i$ and $\hat{x}_j$
-    are quadrature field operators. However, a different basis can of course be used for a symplectic matrix. 
-    Another common way of expressing symplectic matrices is with the block diagonal symplectic form:
-    
-    $$\mathbf{J} = \begin{pmatrix} 0 & \mathbf{I}_N \\ -\mathbf{I}_N & 0 \end{pmatrix},$$
-
-    where $\mathbf{I}_N$ is the identity matrix of size $N \times N$.
+    are quadrature field operators.
 
 This library has a number of predefined Gaussian unitaries, which are listed below:
 

--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -38,10 +38,10 @@ such state vector simulations, we recommend using the [QuantumOptics.jl](https:/
 which can be typed in the Julia REPL as `\otimes<TAB>`. Take the following example, where we produce a 3-mode Gaussian state that consists of a coherent state, vacuumstate, and squeezed state:
 
 ```jldoctest
-julia> repr = CanonicalForm(1);
+julia> basis = QuadPairBasis(1);
 
-julia> coherentstate(repr, -1.0) ⊗ vacuumstate(repr) ⊗ squeezedstate(repr, 0.25, pi/4)
-GaussianState for 3 modes in CanonicalForm representation.
+julia> coherentstate(basis, -1.0) ⊗ vacuumstate(basis) ⊗ squeezedstate(basis, 0.25, pi/4)
+GaussianState for 3 modes in QuadPairBasis representation.
 mean: 6-element Vector{Float64}:
  -1.4142135623730951
   0.0
@@ -115,12 +115,12 @@ Listed below are a list of predefined Gaussian channels supported by Gabs:
     method can be called with an additional noise matrix to create a [`GaussianChannel`](@ref) object. For instance, a noisy displacement operator can be called with [`displace`](@ref) as follows:
 
     ```jldoctest
-    julia> repr = CanonicalForm(1);
+    julia> basis = QuadPairBasis(1);
 
     julia> noise = [1.0 -2.0; 4.0 -3.0];
 
-    julia> displace(repr, 1.0-im, noise)
-    GaussianChannel for 1 mode in CanonicalForm representation.
+    julia> displace(basis, 1.0-im, noise)
+    GaussianChannel for 1 mode in QuadPairBasis representation.
     displacement: 2-element Vector{Float64}:
       1.4142135623730951
      -1.4142135623730951

--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -38,8 +38,10 @@ such state vector simulations, we recommend using the [QuantumOptics.jl](https:/
 which can be typed in the Julia REPL as `\otimes<TAB>`. Take the following example, where we produce a 3-mode Gaussian state that consists of a coherent state, vacuumstate, and squeezed state:
 
 ```jldoctest
-julia> coherentstate(-1.0) ⊗ vacuumstate() ⊗ squeezedstate(0.25, pi/4)
-GaussianState for 3 modes.
+julia> repr = CanonicalForm(1);
+
+julia> coherentstate(repr, -1.0) ⊗ vacuumstate(repr) ⊗ squeezedstate(repr, 0.25, pi/4)
+GaussianState for 3 modes in CanonicalForm representation.
 mean: 6-element Vector{Float64}:
  -1.4142135623730951
   0.0
@@ -113,10 +115,12 @@ Listed below are a list of predefined Gaussian channels supported by Gabs:
     method can be called with an additional noise matrix to create a [`GaussianChannel`](@ref) object. For instance, a noisy displacement operator can be called with [`displace`](@ref) as follows:
 
     ```jldoctest
+    julia> repr = CanonicalForm(1);
+
     julia> noise = [1.0 -2.0; 4.0 -3.0];
 
-    julia> displace(1.0-im, noise)
-    GaussianChannel for 1 mode.
+    julia> displace(repr, 1.0-im, noise)
+    GaussianChannel for 1 mode in CanonicalForm representation.
     displacement: 2-element Vector{Float64}:
       1.4142135623730951
      -1.4142135623730951

--- a/docs/src/tutorials.md
+++ b/docs/src/tutorials.md
@@ -16,14 +16,16 @@ currently has support for the following distributions, which can be called with 
 Below is a code example that plots the wigner distribution of a vacuum state:
 ```@example
 using Gabs, CairoMakie
-state = vacuumstate()
+repr = CanonicalForm(1)
+state = vacuumstate(repr)
 q, p = collect(-5.0:0.5:5.0), collect(-5.0:0.5:5.0) # phase space coordinates
 heatmap(q, p, state, dist = :wigner)
 ```
 Of course, more plotting sugar can be added to this example with internal Makie attributes:
 ```@example
 using Gabs, CairoMakie
-state = vacuumstate()
+repr = CanonicalForm(1)
+state = vacuumstate(repr)
 q, p = collect(-5.0:0.5:5.0), collect(-5.0:0.5:5.0) # phase space coordinates
 fig = Figure(fontsize=15, size = (375, 300), fonts = (; regular="CMU Serif"))
 ax = Axis(fig[1,1], xlabel = L"q", ylabel = L"p")
@@ -41,8 +43,8 @@ follow the [`AbstractArray` interface](https://docs.julialang.org/en/v1/manual/i
 Let's explore this feature in detail, using [StaticArrays.jl](https://github.com/JuliaArrays/StaticArrays.jl) and [SparseArrays.jl](https://github.com/JuliaSparse/SparseArrays.jl) as a case study. To create a coherent state that wraps around pure Julia arrays, the function
 [`coherentstate`](@ref) can be called with a single complex argument:
 ```jldoctest
-julia> coherentstate(1.0-im)
-GaussianState for 1 mode.
+julia> coherentstate(CanonicalForm(1), 1.0-im)
+GaussianState for 1 mode in CanonicalForm representation.
 mean: 2-element Vector{Float64}:
   1.4142135623730951
  -1.4142135623730951
@@ -57,8 +59,8 @@ can specify an array type in its first (and second) arguments. Let's see an exam
 ```jldoctest
 julia> using StaticArrays
 
-julia> state = coherentstate(SVector{2}, SMatrix{2,2}, 1.0-im)
-GaussianState for 1 mode.
+julia> state = coherentstate(SVector{2}, SMatrix{2,2}, CanonicalForm(1), 1.0-im)
+GaussianState for 1 mode in CanonicalForm representation.
 mean: 2-element SVector{2, Float64} with indices SOneTo(2):
   1.4142135623730951
  -1.4142135623730951
@@ -67,7 +69,7 @@ covariance: 2×2 SMatrix{2, 2, Float64, 4} with indices SOneTo(2)×SOneTo(2):
  0.0  1.0
 
 julia> tp = state ⊗ state
-GaussianState for 2 modes.
+GaussianState for 2 modes in CanonicalForm representation.
 mean: 4-element SVector{4, Float64} with indices SOneTo(4):
   1.4142135623730951
  -1.4142135623730951
@@ -82,7 +84,7 @@ covariance: 4×4 SMatrix{4, 4, Float64, 16} with indices SOneTo(4)×SOneTo(4):
 julia> using SparseArrays
 
 julia> ptrace(SparseVector, SparseMatrixCSC, tp, 1)
-GaussianState for 1 mode.
+GaussianState for 1 mode in CanonicalForm representation.
 mean: 2-element SparseVector{Float64, Int64} with 2 stored entries:
   [1]  =  1.41421
   [2]  =  -1.41421
@@ -97,8 +99,8 @@ Importantly, methods that create or manipulate a Gaussian state, such as [`tenso
     and matrices, then you can specify the array type with a single argument. For instance, to initialize a state that contains `Array`s holding numbers of type `Float32` rather
     than `Float64`, simply pass `Array{Float32}` to any relevant Gabs.jl method:
     ```jldoctest
-    julia> state = displace(Array{Float32}, 1.0-im)
-    GaussianUnitary for 1 mode.
+    julia> state = displace(Array{Float32}, CanonicalForm(1), 1.0-im)
+    GaussianUnitary for 1 mode in CanonicalForm representation.
     displacement: 2-element Vector{Float32}:
       1.4142135
      -1.4142135

--- a/docs/src/tutorials.md
+++ b/docs/src/tutorials.md
@@ -16,16 +16,16 @@ currently has support for the following distributions, which can be called with 
 Below is a code example that plots the wigner distribution of a vacuum state:
 ```@example
 using Gabs, CairoMakie
-repr = CanonicalForm(1)
-state = vacuumstate(repr)
+basis = QuadPairBasis(1)
+state = vacuumstate(basis)
 q, p = collect(-5.0:0.5:5.0), collect(-5.0:0.5:5.0) # phase space coordinates
 heatmap(q, p, state, dist = :wigner)
 ```
 Of course, more plotting sugar can be added to this example with internal Makie attributes:
 ```@example
 using Gabs, CairoMakie
-repr = CanonicalForm(1)
-state = vacuumstate(repr)
+basis = QuadPairBasis(1)
+state = vacuumstate(basis)
 q, p = collect(-5.0:0.5:5.0), collect(-5.0:0.5:5.0) # phase space coordinates
 fig = Figure(fontsize=15, size = (375, 300), fonts = (; regular="CMU Serif"))
 ax = Axis(fig[1,1], xlabel = L"q", ylabel = L"p")
@@ -43,8 +43,8 @@ follow the [`AbstractArray` interface](https://docs.julialang.org/en/v1/manual/i
 Let's explore this feature in detail, using [StaticArrays.jl](https://github.com/JuliaArrays/StaticArrays.jl) and [SparseArrays.jl](https://github.com/JuliaSparse/SparseArrays.jl) as a case study. To create a coherent state that wraps around pure Julia arrays, the function
 [`coherentstate`](@ref) can be called with a single complex argument:
 ```jldoctest
-julia> coherentstate(CanonicalForm(1), 1.0-im)
-GaussianState for 1 mode in CanonicalForm representation.
+julia> coherentstate(QuadPairBasis(1), 1.0-im)
+GaussianState for 1 mode in QuadPairBasis representation.
 mean: 2-element Vector{Float64}:
   1.4142135623730951
  -1.4142135623730951
@@ -59,8 +59,8 @@ can specify an array type in its first (and second) arguments. Let's see an exam
 ```jldoctest
 julia> using StaticArrays
 
-julia> state = coherentstate(SVector{2}, SMatrix{2,2}, CanonicalForm(1), 1.0-im)
-GaussianState for 1 mode in CanonicalForm representation.
+julia> state = coherentstate(SVector{2}, SMatrix{2,2}, QuadPairBasis(1), 1.0-im)
+GaussianState for 1 mode in QuadPairBasis representation.
 mean: 2-element SVector{2, Float64} with indices SOneTo(2):
   1.4142135623730951
  -1.4142135623730951
@@ -69,7 +69,7 @@ covariance: 2×2 SMatrix{2, 2, Float64, 4} with indices SOneTo(2)×SOneTo(2):
  0.0  1.0
 
 julia> tp = state ⊗ state
-GaussianState for 2 modes in CanonicalForm representation.
+GaussianState for 2 modes in QuadPairBasis representation.
 mean: 4-element SVector{4, Float64} with indices SOneTo(4):
   1.4142135623730951
  -1.4142135623730951
@@ -84,7 +84,7 @@ covariance: 4×4 SMatrix{4, 4, Float64, 16} with indices SOneTo(4)×SOneTo(4):
 julia> using SparseArrays
 
 julia> ptrace(SparseVector, SparseMatrixCSC, tp, 1)
-GaussianState for 1 mode in CanonicalForm representation.
+GaussianState for 1 mode in QuadPairBasis representation.
 mean: 2-element SparseVector{Float64, Int64} with 2 stored entries:
   [1]  =  1.41421
   [2]  =  -1.41421
@@ -99,8 +99,8 @@ Importantly, methods that create or manipulate a Gaussian state, such as [`tenso
     and matrices, then you can specify the array type with a single argument. For instance, to initialize a state that contains `Array`s holding numbers of type `Float32` rather
     than `Float64`, simply pass `Array{Float32}` to any relevant Gabs.jl method:
     ```jldoctest
-    julia> state = displace(Array{Float32}, CanonicalForm(1), 1.0-im)
-    GaussianUnitary for 1 mode in CanonicalForm representation.
+    julia> state = displace(Array{Float32}, QuadPairBasis(1), 1.0-im)
+    GaussianUnitary for 1 mode in QuadPairBasis representation.
     displacement: 2-element Vector{Float32}:
       1.4142135
      -1.4142135

--- a/src/Gabs.jl
+++ b/src/Gabs.jl
@@ -5,7 +5,7 @@ using BlockArrays: BlockedArray, BlockArray, Block, mortar
 import LinearAlgebra
 using LinearAlgebra: I, det, mul!, diagm, diag, qr
 
-import QuantumInterface: Basis, StateVector, AbstractOperator, apply!, tensor, ⊗
+import QuantumInterface: StateVector, AbstractOperator, apply!, tensor, ⊗
 
 export 
     # types

--- a/src/Gabs.jl
+++ b/src/Gabs.jl
@@ -10,6 +10,8 @@ import QuantumInterface: StateVector, AbstractOperator, apply!, tensor, ⊗
 export 
     # types
     GaussianState, GaussianUnitary, GaussianChannel, Generaldyne,
+    # symplectic representations
+    CanonicalForm, BlockForm,
     # operations
     tensor, ⊗, apply!, ptrace, output, prob,
     # predefined Gaussian states
@@ -29,6 +31,8 @@ export
 include("errors.jl")
 
 include("utils.jl")
+
+include("symplectic.jl")
 
 include("types.jl")
 

--- a/src/Gabs.jl
+++ b/src/Gabs.jl
@@ -5,13 +5,13 @@ using BlockArrays: BlockedArray, BlockArray, Block, mortar
 import LinearAlgebra
 using LinearAlgebra: I, det, mul!, diagm, diag, qr
 
-import QuantumInterface: StateVector, AbstractOperator, apply!, tensor, ⊗
+import QuantumInterface: Basis, StateVector, AbstractOperator, apply!, tensor, ⊗
 
 export 
     # types
     GaussianState, GaussianUnitary, GaussianChannel, Generaldyne,
     # symplectic representations
-    CanonicalForm, BlockForm,
+    QuadPairBasis, QuadBlockBasis,
     # operations
     tensor, ⊗, apply!, ptrace, output, prob,
     # predefined Gaussian states

--- a/src/channels.jl
+++ b/src/channels.jl
@@ -339,20 +339,3 @@ function _changebasis(op::GaussianChannel{B1,D,S}, ::Type{B2}) where {B1<:QuadPa
     noise = T * op.noise * transpose(T)
     return GaussianChannel(B2(nmodes), disp, transform, noise)
 end
-function _changebasis(op::GaussianChannel{B1,D,S}, ::Type{B2}) where {B1<:QuadBlockBasis,B2<:QuadPairBasis,D,S}
-    if B1 == B2
-        return op
-    end
-    basis = op.basis
-    nmodes = basis.nmodes
-    T = zeros(2*nmodes, 2*nmodes)
-    @inbounds for i in Base.OneTo(2*nmodes), j in Base.OneTo(2*nmodes)
-        if (j == 2*i-1) || (j + 2*nmodes == 2*i)
-            T[i,j] = 1
-        end
-    end
-    disp = T * op.disp
-    transform = T * op.transform * transpose(T)
-    noise = T * op.noise * transpose(T)
-    return GaussianChannel(B2(nmodes), disp, transform, noise)
-end

--- a/src/channels.jl
+++ b/src/channels.jl
@@ -2,54 +2,54 @@
 # Predefined Gaussian channels
 ##
 
-function displace(::Type{Td}, ::Type{Tt}, repr::SymplecticRepr{N}, alpha::A, noise::M) where {Td,Tt,N<:Int,A,M}
-    disp, transform = _displace(repr, alpha)
-    return GaussianChannel(repr, Td(disp), Tt(transform), Tt(noise))
+function displace(::Type{Td}, ::Type{Tt}, basis::SymplecticBasis{N}, alpha::A, noise::M) where {Td,Tt,N<:Int,A,M}
+    disp, transform = _displace(basis, alpha)
+    return GaussianChannel(basis, Td(disp), Tt(transform), Tt(noise))
 end
-displace(::Type{T}, repr::SymplecticRepr{N}, alpha::A, noise::M) where {T,N<:Int,A,M} = displace(T, T, repr, alpha, noise)
-function displace(repr::SymplecticRepr{N}, alpha::A, noise::M) where {N<:Int,A,M}
-    disp, transform = _displace(repr, alpha)
-    return GaussianChannel(repr, disp, transform, noise)
-end
-
-function squeeze(::Type{Td}, ::Type{Tt}, repr::SymplecticRepr{N}, r::R, theta::R, noise::M) where {Td,Tt,N<:Int,R,M}
-    disp, transform = _squeeze(repr, r, theta)
-    return GaussianChannel(repr, Td(disp), Tt(transform), Tt(noise))
-end
-squeeze(::Type{T}, repr::SymplecticRepr{N}, r::R, theta::R, noise::M) where {T,N<:Int,R,M} = squeeze(T, T, repr, r, theta, noise)
-function squeeze(repr::SymplecticRepr{N}, r::R, theta::R, noise::M) where {N<:Int,R,M}
-    disp, transform = _squeeze(repr, r, theta)
-    return GaussianChannel(repr, disp, transform, noise)
+displace(::Type{T}, basis::SymplecticBasis{N}, alpha::A, noise::M) where {T,N<:Int,A,M} = displace(T, T, basis, alpha, noise)
+function displace(basis::SymplecticBasis{N}, alpha::A, noise::M) where {N<:Int,A,M}
+    disp, transform = _displace(basis, alpha)
+    return GaussianChannel(basis, disp, transform, noise)
 end
 
-function twosqueeze(::Type{Td}, ::Type{Tt}, repr::SymplecticRepr{N}, r::R, theta::R, noise::M) where {Td,Tt,N<:Int,R,M}
-    disp, transform = _twosqueeze(repr, r, theta)
-    return GaussianChannel(repr, Td(disp), Tt(transform), Tt(noise))
+function squeeze(::Type{Td}, ::Type{Tt}, basis::SymplecticBasis{N}, r::R, theta::R, noise::M) where {Td,Tt,N<:Int,R,M}
+    disp, transform = _squeeze(basis, r, theta)
+    return GaussianChannel(basis, Td(disp), Tt(transform), Tt(noise))
 end
-twosqueeze(::Type{T}, repr::SymplecticRepr{N}, r::R, theta::R, noise::M) where {T,N<:Int,R,M} = twosqueeze(T, T, repr, r, theta, noise)
-function twosqueeze(repr::SymplecticRepr{N}, r::R, theta::R, noise::M) where {N<:Int,R,M}
-    disp, transform = _twosqueeze(repr, r, theta)
-    return GaussianChannel(repr, disp, transform, noise)
-end
-
-function phaseshift(::Type{Td}, ::Type{Tt}, repr::SymplecticRepr{N}, theta::R, noise::M) where {Td,Tt,N<:Int,R,M}
-    disp, transform = _phaseshift(repr, theta)
-    return GaussianChannel(repr, Td(disp), Tt(transform), Tt(noise))
-end
-phaseshift(::Type{T}, repr::SymplecticRepr{N}, theta::R, noise::M) where {T,N<:Int,R,M} = phaseshift(T, T, repr, theta, noise)
-function phaseshift(repr::SymplecticRepr{N}, theta::R, noise::M) where {N<:Int,R,M}
-    disp, transform = _phaseshift(repr, theta)
-    return GaussianChannel(repr, disp, transform, noise)
+squeeze(::Type{T}, basis::SymplecticBasis{N}, r::R, theta::R, noise::M) where {T,N<:Int,R,M} = squeeze(T, T, basis, r, theta, noise)
+function squeeze(basis::SymplecticBasis{N}, r::R, theta::R, noise::M) where {N<:Int,R,M}
+    disp, transform = _squeeze(basis, r, theta)
+    return GaussianChannel(basis, disp, transform, noise)
 end
 
-function beamsplitter(::Type{Td}, ::Type{Tt}, repr::SymplecticRepr{N}, transmit::R, noise::M) where {Td,Tt,N<:Int,R,M}
-    disp, transform = _beamsplitter(repr, transmit)
-    return GaussianChannel(repr, Td(disp), Tt(transform), Tt(noise))
+function twosqueeze(::Type{Td}, ::Type{Tt}, basis::SymplecticBasis{N}, r::R, theta::R, noise::M) where {Td,Tt,N<:Int,R,M}
+    disp, transform = _twosqueeze(basis, r, theta)
+    return GaussianChannel(basis, Td(disp), Tt(transform), Tt(noise))
 end
-beamsplitter(::Type{T}, repr::SymplecticRepr{N}, transmit::R, noise::M) where {T,N<:Int,R,M} = beamsplitter(T, T, repr, transmit, noise)
-function beamsplitter(repr::SymplecticRepr{N}, transmit::R, noise::M) where {N<:Int,R,M}
-    disp, transform = _beamsplitter(repr, transmit)
-    return GaussianChannel(repr, disp, transform, noise)
+twosqueeze(::Type{T}, basis::SymplecticBasis{N}, r::R, theta::R, noise::M) where {T,N<:Int,R,M} = twosqueeze(T, T, basis, r, theta, noise)
+function twosqueeze(basis::SymplecticBasis{N}, r::R, theta::R, noise::M) where {N<:Int,R,M}
+    disp, transform = _twosqueeze(basis, r, theta)
+    return GaussianChannel(basis, disp, transform, noise)
+end
+
+function phaseshift(::Type{Td}, ::Type{Tt}, basis::SymplecticBasis{N}, theta::R, noise::M) where {Td,Tt,N<:Int,R,M}
+    disp, transform = _phaseshift(basis, theta)
+    return GaussianChannel(basis, Td(disp), Tt(transform), Tt(noise))
+end
+phaseshift(::Type{T}, basis::SymplecticBasis{N}, theta::R, noise::M) where {T,N<:Int,R,M} = phaseshift(T, T, basis, theta, noise)
+function phaseshift(basis::SymplecticBasis{N}, theta::R, noise::M) where {N<:Int,R,M}
+    disp, transform = _phaseshift(basis, theta)
+    return GaussianChannel(basis, disp, transform, noise)
+end
+
+function beamsplitter(::Type{Td}, ::Type{Tt}, basis::SymplecticBasis{N}, transmit::R, noise::M) where {Td,Tt,N<:Int,R,M}
+    disp, transform = _beamsplitter(basis, transmit)
+    return GaussianChannel(basis, Td(disp), Tt(transform), Tt(noise))
+end
+beamsplitter(::Type{T}, basis::SymplecticBasis{N}, transmit::R, noise::M) where {T,N<:Int,R,M} = beamsplitter(T, T, basis, transmit, noise)
+function beamsplitter(basis::SymplecticBasis{N}, transmit::R, noise::M) where {N<:Int,R,M}
+    disp, transform = _beamsplitter(basis, transmit)
+    return GaussianChannel(basis, disp, transform, noise)
 end
 
 """
@@ -75,8 +75,8 @@ and noise matrix ``\\mathbf{N}``, expressed respectively as follows:
 ## Example
 
 ```jldoctest
-julia> attenuator(CanonicalForm(1), pi/6, 3)
-GaussianChannel for 1 mode in CanonicalForm representation.
+julia> attenuator(QuadPairBasis(1), pi/6, 3)
+GaussianChannel for 1 mode in QuadPairBasis representation.
 displacement: 2-element Vector{Float64}:
  0.0
  0.0
@@ -88,24 +88,24 @@ noise: 2×2 Matrix{Float64}:
  0.0   0.75
 ```
 """
-function attenuator(::Type{Td}, ::Type{Tt}, repr::SymplecticRepr{N}, theta::R, n::M) where {Td,Tt,N<:Int,R,M}
-    disp, transform, noise = _attenuator(repr, theta, n)
-    return GaussianChannel(repr, Td(disp), Tt(transform), Tt(noise))
+function attenuator(::Type{Td}, ::Type{Tt}, basis::SymplecticBasis{N}, theta::R, n::M) where {Td,Tt,N<:Int,R,M}
+    disp, transform, noise = _attenuator(basis, theta, n)
+    return GaussianChannel(basis, Td(disp), Tt(transform), Tt(noise))
 end
-attenuator(::Type{T}, repr::SymplecticRepr{N}, theta::R, n::M) where {T,N<:Int,R,M} = attenuator(T, T, repr, theta, n)
-function attenuator(repr::SymplecticRepr{N}, theta::R, n::M) where {N<:Int,R,M}
-    disp, transform, noise = _attenuator(repr, theta, n)
-    return GaussianChannel(repr, disp, transform, noise)
+attenuator(::Type{T}, basis::SymplecticBasis{N}, theta::R, n::M) where {T,N<:Int,R,M} = attenuator(T, T, basis, theta, n)
+function attenuator(basis::SymplecticBasis{N}, theta::R, n::M) where {N<:Int,R,M}
+    disp, transform, noise = _attenuator(basis, theta, n)
+    return GaussianChannel(basis, disp, transform, noise)
 end
-function _attenuator(repr::CanonicalForm{N}, theta::R, n::M) where {N<:Int,R<:Real,M<:Int}
-    nmodes = repr.nmodes
+function _attenuator(basis::QuadPairBasis{N}, theta::R, n::M) where {N<:Int,R<:Real,M<:Int}
+    nmodes = basis.nmodes
     disp = zeros(2*nmodes) 
     transform = Matrix{Float64}(cos(theta) * I, 2*nmodes, 2*nmodes)
     noise = Matrix{Float64}((sin(theta))^2 * n * I, 2*nmodes, 2*nmodes)
     return disp, transform, noise
 end
-function _attenuator(repr::CanonicalForm{N}, theta::R, n::M) where {N<:Int,R<:Vector,M<:Vector}
-    nmodes = repr.nmodes
+function _attenuator(basis::QuadPairBasis{N}, theta::R, n::M) where {N<:Int,R<:Vector,M<:Vector}
+    nmodes = basis.nmodes
     disp = zeros(2*nmodes) 
     transform = zeros(2*nmodes, 2*nmodes)
     noise = zeros(2*nmodes, 2*nmodes)
@@ -145,8 +145,8 @@ and noise matrix ``\\mathbf{N}``, expressed respectively as follows:
 ## Example
 
 ```jldoctest
-julia> amplifier(CanonicalForm(1), 2.0, 3)
-GaussianChannel for 1 mode in CanonicalForm representation.
+julia> amplifier(QuadPairBasis(1), 2.0, 3)
+GaussianChannel for 1 mode in QuadPairBasis representation.
 displacement: 2-element Vector{Float64}:
  0.0
  0.0
@@ -158,24 +158,24 @@ noise: 2×2 Matrix{Float64}:
   0.0     39.4623
 ```
 """
-function amplifier(::Type{Td}, ::Type{Tt}, repr::SymplecticRepr{N}, r::R, n::M) where {Td,Tt,N<:Int,R,M}
-    disp, transform, noise = _amplifier(repr, r, n)
-    return GaussianChannel(repr, Td(disp), Tt(transform), Tt(noise))
+function amplifier(::Type{Td}, ::Type{Tt}, basis::SymplecticBasis{N}, r::R, n::M) where {Td,Tt,N<:Int,R,M}
+    disp, transform, noise = _amplifier(basis, r, n)
+    return GaussianChannel(basis, Td(disp), Tt(transform), Tt(noise))
 end
-amplifier(::Type{T}, repr::SymplecticRepr{N}, r::R, n::M) where {T,N<:Int,R,M} = amplifier(T, T, repr, r, n)
-function amplifier(repr::SymplecticRepr{N}, r::R, n::M) where {N<:Int,R,M}
-    disp, transform, noise = _amplifier(repr, r, n)
-    return GaussianChannel(repr, disp, transform, noise)
+amplifier(::Type{T}, basis::SymplecticBasis{N}, r::R, n::M) where {T,N<:Int,R,M} = amplifier(T, T, basis, r, n)
+function amplifier(basis::SymplecticBasis{N}, r::R, n::M) where {N<:Int,R,M}
+    disp, transform, noise = _amplifier(basis, r, n)
+    return GaussianChannel(basis, disp, transform, noise)
 end
-function _amplifier(repr::CanonicalForm{N}, r::R, n::M) where {N<:Int,R<:Real,M<:Int}
-    nmodes = repr.nmodes
+function _amplifier(basis::QuadPairBasis{N}, r::R, n::M) where {N<:Int,R<:Real,M<:Int}
+    nmodes = basis.nmodes
     disp = zeros(2*nmodes) 
     transform = Matrix{Float64}(cosh(r) * I, 2*nmodes, 2*nmodes)
     noise = Matrix{Float64}((sinh(r))^2 * n * I, 2*nmodes, 2*nmodes)
     return disp, transform, noise
 end
-function _amplifier(repr::CanonicalForm{N}, r::R, n::M) where {N<:Int,R<:Vector,M<:Vector}
-    nmodes = repr.nmodes
+function _amplifier(basis::QuadPairBasis{N}, r::R, n::M) where {N<:Int,R<:Vector,M<:Vector}
+    nmodes = basis.nmodes
     disp = zeros(2*nmodes) 
     transform = zeros(2*nmodes, 2*nmodes)
     noise = zeros(2*nmodes, 2*nmodes)
@@ -198,17 +198,17 @@ end
 
 function tensor(::Type{Td}, ::Type{Tt}, op1::GaussianChannel, op2::GaussianChannel) where {Td,Tt}
     disp, transform, noise = _tensor(op1, op2)
-    return GaussianChannel(op1.repr + op2.repr, Td(disp), Tt(transform), Tt(noise))
+    return GaussianChannel(op1.basis + op2.basis, Td(disp), Tt(transform), Tt(noise))
 end
 tensor(::Type{T}, op1::GaussianChannel, op2::GaussianChannel) where {T} = tensor(T, T, op1, op2)
 function tensor(op1::GaussianChannel, op2::GaussianChannel)
     disp, transform, noise = _tensor(op1, op2)
-    return GaussianChannel(op1.repr + op2.repr, disp, transform, noise)
+    return GaussianChannel(op1.basis + op2.basis, disp, transform, noise)
 end
 function _tensor(op1::GaussianChannel, op2::GaussianChannel)
     disp1, disp2 = op1.disp, op2.disp
-    repr1, repr2 = op1.repr, op2.repr
-    length1, length2 = 2*repr1.nmodes, 2*repr2.nmodes
+    basis1, basis2 = op1.basis, op2.basis
+    length1, length2 = 2*basis1.nmodes, 2*basis2.nmodes
     slengths = length1 + length2
     trans1, trans2 = op1.transform, op2.transform
     # initialize direct sum of displacement vectors

--- a/src/channels.jl
+++ b/src/channels.jl
@@ -287,3 +287,38 @@ function _tensor(op1::GaussianChannel{B1,D1,T1}, op2::GaussianChannel{B2,D2,T2})
     noise′′ = _promote_output_matrix(typeof(noise1), typeof(noise2), noise′)
     return disp′′, transform′′, noise′′
 end
+
+function _changebasis(op::GaussianChannel{B1,D,S}, ::Type{B2}) where {B1<:QuadPairBasis,B2<:QuadBlockBasis,D,S}
+    if B1 == B2
+        return op
+    end
+    basis = op.basis
+    nmodes = basis.nmodes
+    T = zeros(2*nmodes, 2*nmodes)
+    @inbounds for i in Base.OneTo(2*nmodes), j in Base.OneTo(2*nmodes)
+        if (j == 2*i-1) || (j + 2*nmodes == 2*i)
+            T[i,j] = 1
+        end
+    end
+    disp = T * op.disp
+    transform = T * op.transform * transpose(T)
+    noise = T * op.noise * transpose(T)
+    return GaussianChannel(B2(nmodes), disp, transform, noise)
+end
+function _changebasis(op::GaussianChannel{B1,D,S}, ::Type{B2}) where {B1<:QuadBlockBasis,B2<:QuadPairBasis,D,S}
+    if B1 == B2
+        return op
+    end
+    basis = op.basis
+    nmodes = basis.nmodes
+    T = zeros(2*nmodes, 2*nmodes)
+    @inbounds for i in Base.OneTo(2*nmodes), j in Base.OneTo(2*nmodes)
+        if (j == 2*i-1) || (j + 2*nmodes == 2*i)
+            T[i,j] = 1
+        end
+    end
+    disp = T * op.disp
+    transform = transpose(T) * op.transform * T
+    noise = transpose(T) * op.noise * T
+    return GaussianChannel(B2(nmodes), disp, transform, noise)
+end

--- a/src/channels.jl
+++ b/src/channels.jl
@@ -2,73 +2,54 @@
 # Predefined Gaussian channels
 ##
 
-function displace(::Type{Td}, ::Type{Tt}, alpha::A, noise::N) where {Td,Tt,A<:Number,N}
-    disp =  Td(sqrt(2) * [real(alpha), imag(alpha)])
-    transform = Tt(Matrix{Float64}(I, 2, 2))
-    return GaussianChannel(disp, transform, Tt(noise), 1)
+function displace(::Type{Td}, ::Type{Tt}, repr::SymplecticRepr{N}, alpha::A, noise::M) where {Td,Tt,N<:Int,A,M}
+    disp, transform = _displace(repr, alpha)
+    return GaussianChannel(repr, Td(disp), Tt(transform), Tt(noise))
 end
-displace(::Type{T}, alpha::A, noise::N) where {T,A<:Number,N} = displace(T, T, alpha, noise)
-function displace(alpha::A, noise::N) where {A<:Number,N}
-    disp = sqrt(2) * [real(alpha), imag(alpha)]
-    transform = Matrix{Float64}(I, 2, 2)
-    return GaussianChannel(disp, transform, noise, 1)
+displace(::Type{T}, repr::SymplecticRepr{N}, alpha::A, noise::M) where {T,N<:Int,A,M} = displace(T, T, repr, alpha, noise)
+function displace(repr::SymplecticRepr{N}, alpha::A, noise::M) where {N<:Int,A,M}
+    disp, transform = _displace(repr, alpha)
+    return GaussianChannel(repr, disp, transform, noise)
 end
 
-function squeeze(::Type{Td}, ::Type{Tt}, r::R, theta::R, noise::N) where {Td,Tt,R<:Real,N}
-    disp = Td(zeros(2))
-    cr, sr = cosh(r), sinh(r)
-    t = sinh(r) * [cr-sr*cos(theta) sr*sin(theta); sr*sin(theta) cr+sr*cos(theta)]
-    transform = Tt(t)
-    return GaussianChannel(disp, transform, Tt(noise), 1)
+function squeeze(::Type{Td}, ::Type{Tt}, repr::SymplecticRepr{N}, r::R, theta::R, noise::M) where {Td,Tt,N<:Int,R,M}
+    disp, transform = _squeeze(repr, r, theta)
+    return GaussianChannel(repr, Td(disp), Tt(transform), Tt(noise))
 end
-squeeze(::Type{T}, r::R, theta::R, noise::N) where {T,R<:Real,N} = squeeze(T, T, r, theta, noise)
-function squeeze(r::R, theta::R, noise::N) where {R<:Real,N}
-    disp = zeros(2)
-    cr, sr = cosh(r), sinh(r)
-    transform = sinh(r) * [cr-sr*cos(theta) sr*sin(theta); sr*sin(theta) cr+sr*cos(theta)]
-    return GaussianChannel(disp, transform, noise, 1)
+squeeze(::Type{T}, repr::SymplecticRepr{N}, r::R, theta::R, noise::M) where {T,N<:Int,R,M} = squeeze(T, T, repr, r, theta, noise)
+function squeeze(repr::SymplecticRepr{N}, r::R, theta::R, noise::M) where {N<:Int,R,M}
+    disp, transform = _squeeze(repr, r, theta)
+    return GaussianChannel(repr, disp, transform, noise)
 end
 
-function twosqueeze(::Type{Td}, ::Type{Tt}, r::R, theta::R, noise::N) where {Td,Tt,R<:Real,N}
-    disp = Td(zeros(4))
-    cr, sr = cosh(r), sinh(r)
-    ct, st = cos(theta), sin(theta)
-    transform = Tt([cr 0.0 -sr*ct -sr*st; 0.0 cr -sr*st sr*ct; -sr*ct -sr*st cr 0.0; -sr*st sr*ct 0.0 cr])
-    return GaussianChannel(disp, transform, Tt(noise), 2)
+function twosqueeze(::Type{Td}, ::Type{Tt}, repr::SymplecticRepr{N}, r::R, theta::R, noise::M) where {Td,Tt,N<:Int,R,M}
+    disp, transform = _twosqueeze(repr, r, theta)
+    return GaussianChannel(repr, Td(disp), Tt(transform), Tt(noise))
 end
-twosqueeze(::Type{T}, r::R, theta::R, noise::N) where {T,R<:Real,N} = twosqueeze(T, T, r, theta, noise)
-function twosqueeze(r::R, theta::R, noise::N) where {R<:Real,N}
-    disp = zeros(4)
-    cr, sr = cosh(r), sinh(r)
-    ct, st = cos(theta), sin(theta)
-    transform = [cr 0.0 -sr*ct -sr*st; 0.0 cr -sr*st sr*ct; -sr*ct -sr*st cr 0.0; -sr*st sr*ct 0.0 cr]
-    return GaussianChannel(disp, transform, noise, 2)
+twosqueeze(::Type{T}, repr::SymplecticRepr{N}, r::R, theta::R, noise::M) where {T,N<:Int,R,M} = twosqueeze(T, T, repr, r, theta, noise)
+function twosqueeze(repr::SymplecticRepr{N}, r::R, theta::R, noise::M) where {N<:Int,R,M}
+    disp, transform = _twosqueeze(repr, r, theta)
+    return GaussianChannel(repr, disp, transform, noise)
 end
 
-function phaseshift(::Type{Td}, ::Type{Tt}, theta::R, noise::N) where {Td,Tt,R<:Real,N}
-    disp = Td(zeros(2))
-    transform = Tt([cos(theta) sin(theta); -sin(theta) cos(theta)])
-    return GaussianChannel(disp, transform, Tt(noise), 1)
+function phaseshift(::Type{Td}, ::Type{Tt}, repr::SymplecticRepr{N}, theta::R, noise::M) where {Td,Tt,N<:Int,R,M}
+    disp, transform = _phaseshift(repr, theta)
+    return GaussianChannel(repr, Td(disp), Tt(transform), Tt(noise))
 end
-phaseshift(::Type{T}, theta::R, noise::N) where {T,R<:Real,N} = phaseshift(T, T, theta, noise)
-function phaseshift(theta::R, noise::N) where {R<:Real,N}
-    disp = zeros(2)
-    transform = [cos(theta) sin(theta); -sin(theta) cos(theta)]
-    return GaussianChannel(disp, transform, noise, 1)
+phaseshift(::Type{T}, repr::SymplecticRepr{N}, theta::R, noise::M) where {T,N<:Int,R,M} = phaseshift(T, T, repr, theta, noise)
+function phaseshift(repr::SymplecticRepr{N}, theta::R, noise::M) where {N<:Int,R,M}
+    disp, transform = _phaseshift(repr, theta)
+    return GaussianChannel(repr, disp, transform, noise)
 end
 
-function beamsplitter(::Type{Td}, ::Type{Tt}, transmit::R, noise::N) where {Td,Tt,R<:Real,N}
-    disp = Td(zeros(4))
-    a1, a2 = sqrt(transmit), sqrt(1 - transmit)
-    transform = Tt([a1 0.0 a2 0.0; 0.0 a1 0.0 a2; -a2 0.0 a1 0.0; 0.0 -a2 0.0 a1])
-    return GaussianChannel(disp, transform, Tt(noise), 2)
+function beamsplitter(::Type{Td}, ::Type{Tt}, repr::SymplecticRepr{N}, transmit::R, noise::M) where {Td,Tt,N<:Int,R,M}
+    disp, transform = _beamsplitter(repr, transmit)
+    return GaussianChannel(repr, Td(disp), Tt(transform), Tt(noise))
 end
-beamsplitter(::Type{T}, transmit::R, noise::N) where {T,R<:Real,N} = beamsplitter(T, T, transmit, noise)
-function beamsplitter(transmit::R, noise::N) where {R<:Real,N}
-    disp = zeros(4)
-    a1, a2 = sqrt(transmit), sqrt(1 - transmit)
-    transform = [a1 0.0 a2 0.0; 0.0 a1 0.0 a2; -a2 0.0 a1 0.0; 0.0 -a2 0.0 a1]
-    return GaussianChannel(disp, transform, noise, 2)
+beamsplitter(::Type{T}, repr::SymplecticRepr{N}, transmit::R, noise::M) where {T,N<:Int,R,M} = beamsplitter(T, T, repr, transmit, noise)
+function beamsplitter(repr::SymplecticRepr{N}, transmit::R, noise::M) where {N<:Int,R,M}
+    disp, transform = _beamsplitter(repr, transmit)
+    return GaussianChannel(repr, disp, transform, noise)
 end
 
 """
@@ -94,8 +75,8 @@ and noise matrix ``\\mathbf{N}``, expressed respectively as follows:
 ## Example
 
 ```jldoctest
-julia> attenuator(pi/6, 3)
-GaussianChannel for 1 mode.
+julia> attenuator(CanonicalForm(1), pi/6, 3)
+GaussianChannel for 1 mode in CanonicalForm representation.
 displacement: 2-element Vector{Float64}:
  0.0
  0.0
@@ -107,18 +88,38 @@ noise: 2×2 Matrix{Float64}:
  0.0   0.75
 ```
 """
-function attenuator(::Type{Td}, ::Type{Tt}, theta::R, n::N) where {Td,Tt,R<:Real,N<:Int}
-    disp = zeros(2)
-    transform = cos(theta) * Matrix{Float64}(I, 2, 2)
-    noise = (sin(theta))^2 * n * Matrix{Float64}(I, 2, 2)
-    return GaussianChannel(Td(disp), Tt(transform), Tt(noise), 1)
+function attenuator(::Type{Td}, ::Type{Tt}, repr::SymplecticRepr{N}, theta::R, n::M) where {Td,Tt,N<:Int,R,M}
+    disp, transform, noise = _attenuator(repr, theta, n)
+    return GaussianChannel(repr, Td(disp), Tt(transform), Tt(noise))
 end
-attenuator(::Type{T}, theta::R, n::N) where {T,R<:Real,N<:Int} = attenuator(T, T, theta, n)
-function attenuator(theta::R, n::N) where {R<:Real,N<:Int}
-    disp = zeros(2)
-    transform = cos(theta) * Matrix{Float64}(I, 2, 2)
-    noise = (sin(theta))^2 * n * Matrix{Float64}(I, 2, 2)
-    return GaussianChannel(disp, transform, noise, 1)
+attenuator(::Type{T}, repr::SymplecticRepr{N}, theta::R, n::M) where {T,N<:Int,R,M} = attenuator(T, T, repr, theta, n)
+function attenuator(repr::SymplecticRepr{N}, theta::R, n::M) where {N<:Int,R,M}
+    disp, transform, noise = _attenuator(repr, theta, n)
+    return GaussianChannel(repr, disp, transform, noise)
+end
+function _attenuator(repr::CanonicalForm{N}, theta::R, n::M) where {N<:Int,R<:Real,M<:Int}
+    nmodes = repr.nmodes
+    disp = zeros(2*nmodes) 
+    transform = Matrix{Float64}(cos(theta) * I, 2*nmodes, 2*nmodes)
+    noise = Matrix{Float64}((sin(theta))^2 * n * I, 2*nmodes, 2*nmodes)
+    return disp, transform, noise
+end
+function _attenuator(repr::CanonicalForm{N}, theta::R, n::M) where {N<:Int,R<:Vector,M<:Vector}
+    nmodes = repr.nmodes
+    disp = zeros(2*nmodes) 
+    transform = zeros(2*nmodes, 2*nmodes)
+    noise = zeros(2*nmodes, 2*nmodes)
+    @inbounds for i in Base.OneTo(nmodes)
+        ct, st = cos(theta[i]), sin(theta[i])
+        ni = n[i]
+
+        transform[2*i-1, 2*i-1] = ct
+        transform[2*i, 2*i] = ct
+
+        noise[2*i-1, 2*i-1] = st^2 * ni
+        noise[2*i, 2*i] = st^2 * ni
+    end
+    return disp, transform, noise
 end
 
 """
@@ -144,8 +145,8 @@ and noise matrix ``\\mathbf{N}``, expressed respectively as follows:
 ## Example
 
 ```jldoctest
-julia> amplifier(2.0, 3)
-GaussianChannel for 1 mode.
+julia> amplifier(CanonicalForm(1), 2.0, 3)
+GaussianChannel for 1 mode in CanonicalForm representation.
 displacement: 2-element Vector{Float64}:
  0.0
  0.0
@@ -157,18 +158,38 @@ noise: 2×2 Matrix{Float64}:
   0.0     39.4623
 ```
 """
-function amplifier(::Type{Td}, ::Type{Tt}, r::R, n::N) where {Td,Tt,R<:Real,N<:Int}
-    disp = zeros(2)
-    transform = cosh(r) * Matrix{Float64}(I, 2, 2)
-    noise = (sinh(r))^2 * n * Matrix{Float64}(I, 2, 2)
-    return GaussianChannel(Td(disp), Tt(transform), Tt(noise), 1)
+function amplifier(::Type{Td}, ::Type{Tt}, repr::SymplecticRepr{N}, r::R, n::M) where {Td,Tt,N<:Int,R,M}
+    disp, transform, noise = _amplifier(repr, r, n)
+    return GaussianChannel(repr, Td(disp), Tt(transform), Tt(noise))
 end
-amplifier(::Type{T}, r::R, n::N) where {T,R<:Real,N<:Int} = amplifier(T, T, r, n)
-function amplifier(r::R, n::N) where {R<:Real,N<:Int}
-    disp = zeros(2)
-    transform = cosh(r) * Matrix{Float64}(I, 2, 2)
-    noise = (sinh(r))^2 * n * Matrix{Float64}(I, 2, 2)
-    return GaussianChannel(disp, transform, noise, 1)
+amplifier(::Type{T}, repr::SymplecticRepr{N}, r::R, n::M) where {T,N<:Int,R,M} = amplifier(T, T, repr, r, n)
+function amplifier(repr::SymplecticRepr{N}, r::R, n::M) where {N<:Int,R,M}
+    disp, transform, noise = _amplifier(repr, r, n)
+    return GaussianChannel(repr, disp, transform, noise)
+end
+function _amplifier(repr::CanonicalForm{N}, r::R, n::M) where {N<:Int,R<:Real,M<:Int}
+    nmodes = repr.nmodes
+    disp = zeros(2*nmodes) 
+    transform = Matrix{Float64}(cosh(r) * I, 2*nmodes, 2*nmodes)
+    noise = Matrix{Float64}((sinh(r))^2 * n * I, 2*nmodes, 2*nmodes)
+    return disp, transform, noise
+end
+function _amplifier(repr::CanonicalForm{N}, r::R, n::M) where {N<:Int,R<:Vector,M<:Vector}
+    nmodes = repr.nmodes
+    disp = zeros(2*nmodes) 
+    transform = zeros(2*nmodes, 2*nmodes)
+    noise = zeros(2*nmodes, 2*nmodes)
+    @inbounds for i in Base.OneTo(nmodes)
+        cr, sr = cos(r[i]), sin(r[i])
+        ni = n[i]
+
+        transform[2*i-1, 2*i-1] = cr
+        transform[2*i, 2*i] = cr
+
+        noise[2*i-1, 2*i-1] = sr^2 * ni
+        noise[2*i, 2*i] = sr^2 * ni
+    end
+    return disp, transform, noise
 end
 
 ##
@@ -176,17 +197,18 @@ end
 ##
 
 function tensor(::Type{Td}, ::Type{Tt}, op1::GaussianChannel, op2::GaussianChannel) where {Td,Tt}
-    disp′, transform′, noise′ = _tensor_fields(op1, op2)
-    return GaussianChannel(Td(disp′), Tt(transform′), Tt(noise′), op1.nmodes + op2.nmodes)
+    disp, transform, noise = _tensor(op1, op2)
+    return GaussianChannel(op1.repr + op2.repr, Td(disp), Tt(transform), Tt(noise))
 end
 tensor(::Type{T}, op1::GaussianChannel, op2::GaussianChannel) where {T} = tensor(T, T, op1, op2)
 function tensor(op1::GaussianChannel, op2::GaussianChannel)
-    disp′, transform′, noise′ = _tensor_fields(op1, op2)
-    return GaussianChannel(disp′, transform′, noise′, op1.nmodes + op2.nmodes)
+    disp, transform, noise = _tensor(op1, op2)
+    return GaussianChannel(op1.repr + op2.repr, disp, transform, noise)
 end
-function _tensor_fields(op1::GaussianChannel, op2::GaussianChannel)
+function _tensor(op1::GaussianChannel, op2::GaussianChannel)
     disp1, disp2 = op1.disp, op2.disp
-    length1, length2 = 2*op1.nmodes, 2*op2.nmodes
+    repr1, repr2 = op1.repr, op2.repr
+    length1, length2 = 2*repr1.nmodes, 2*repr2.nmodes
     slengths = length1 + length2
     trans1, trans2 = op1.transform, op2.transform
     # initialize direct sum of displacement vectors

--- a/src/channels.jl
+++ b/src/channels.jl
@@ -53,7 +53,7 @@ function beamsplitter(basis::SymplecticBasis{N}, transmit::R, noise::M) where {N
 end
 
 """
-    attenuator([Td=Vector{Float64}, Tt=Matrix{Float64},] theta<:Real, n<:Int)
+    attenuator([Td=Vector{Float64}, Tt=Matrix{Float64},] basis::SymplecticBasis, theta<:Real, n<:Int)
 
 Gaussian channel describing the coupling of an input
 single mode Gaussian state and its environment via a beam splitter operation. The channel is paramatrized
@@ -123,7 +123,7 @@ function _attenuator(basis::QuadPairBasis{N}, theta::R, n::M) where {N<:Int,R<:V
 end
 
 """
-    amplifier([Td=Vector{Float64}, Tt=Matrix{Float64},] r<:Real, n<:Int)
+    amplifier([Td=Vector{Float64}, Tt=Matrix{Float64},] basis::SymplecticBasis, r<:Real, n<:Int)
 
 Gaussian channel describing the interaction of an input
 single mode Gaussian state and its environment via a two-mode squeezing operation. The channel is paramatrized

--- a/src/errors.jl
+++ b/src/errors.jl
@@ -1,3 +1,4 @@
+SYMPLECTIC_ERROR = lazy"The symplectic forms of the Gaussian objects do not match."
 
 STATE_ERROR = lazy"Either the input covariance matrix is not
     square or its dimensions do not match the mean vector. An
@@ -16,7 +17,8 @@ CHANNEL_ERROR = lazy"Either an input matrix is not square or
     of size 2N x 2N." 
 
 ACTION_ERROR = lazy"The number of modes for the Gaussian operator
-    does not match the number of modes for the Gaussian state."
+    does not match the number of modes for the Gaussian state, or the symplectic representations for
+    the two types are different."
 
 GENERALDYNE_ERROR = lazy"The number of modes for the measurement state
     does not match the number of modes for the projected subsystem."

--- a/src/measurements.jl
+++ b/src/measurements.jl
@@ -17,10 +17,12 @@ a measurement outcome Gaussian state ``\\hat{\\rho}(\\mathbf{\\bar{x}}_{m}, \\ma
 ## Example
 
 ```jldoctest
-julia> vac = vacuumstate(); coh = coherentstate(1.0-im);
+julia> repr = CanonicalForm(1);
+
+julia> vac = vacuumstate(repr); coh = coherentstate(repr, 1.0-im);
 
 julia> state = vac ⊗ coh ⊗ vac ⊗ coh
-GaussianState for 4 modes.
+GaussianState for 4 modes in CanonicalForm representation.
 mean: 8-element Vector{Float64}:
   0.0
   0.0
@@ -42,9 +44,9 @@ covariance: 8×8 Matrix{Float64}:
 
 julia> Generaldyne(state, coh ⊗ vac ⊗ coh, [1, 3, 4])
 Generaldyne on indices [1, 3, 4]
-system: GaussianState for 4 modes.
+system: GaussianState for 4 modes in CanonicalForm representation.
  (xType: Vector{Float64} | vType: Matrix{Float64})
-outcome: GaussianState for 3 modes.
+outcome: GaussianState for 3 modes in CanonicalForm representation.
  (xType: Vector{Float64} | vType: Matrix{Float64})
 ```
 """
@@ -53,7 +55,9 @@ struct Generaldyne{I} <: AbstractGeneraldyne
     outcome::GaussianState
     indices::I
     function Generaldyne(sys::GaussianState, outcome::GaussianState, ind::I) where {I}
-        length(ind) == outcome.nmodes || throw(DimensionMismatch(GENERALDYNE_ERROR))
+        sysrepr, outrepr = sys.repr, outcome.repr
+        typeof(sysrepr) == typeof(outrepr) || throw(ArgumentError(SYMPLECTIC_ERROR))
+        length(ind) == outrepr.nmodes || throw(DimensionMismatch(GENERALDYNE_ERROR))
         return new{I}(sys, outcome, ind)
     end
 end
@@ -93,10 +97,12 @@ subsystem ``A`` conditionally maps as follows:
 ## Example
 
 ```jldoctest
-julia> vac = vacuumstate(); coh = coherentstate(1.0-im);
+julia> repr = CanonicalForm(1);
+
+julia> vac = vacuumstate(repr); coh = coherentstate(repr, 1.0-im);
 
 julia> state = vac ⊗ coh ⊗ vac ⊗ coh
-GaussianState for 4 modes.
+GaussianState for 4 modes in CanonicalForm representation.
 mean: 8-element Vector{Float64}:
   0.0
   0.0
@@ -118,13 +124,13 @@ covariance: 8×8 Matrix{Float64}:
 
 julia> gd = Generaldyne(state, coh ⊗ vac ⊗ coh, [1, 3, 4])
 Generaldyne on indices [1, 3, 4]
-system: GaussianState for 4 modes.
+system: GaussianState for 4 modes in CanonicalForm representation.
  (xType: Vector{Float64} | vType: Matrix{Float64})
-outcome: GaussianState for 3 modes.
+outcome: GaussianState for 3 modes in CanonicalForm representation.
  (xType: Vector{Float64} | vType: Matrix{Float64})
 
 julia> output(gd)
-GaussianState for 1 mode.
+GaussianState for 1 mode in CanonicalForm representation.
 mean: 2-element Vector{Float64}:
   1.4142135623730951
  -1.4142135623730951
@@ -135,20 +141,21 @@ covariance: 2×2 Matrix{Float64}:
 """
 function output(meas::Generaldyne)
     sys, outcome, ind = meas.system, meas.outcome, meas.indices
+    sysrepr, outrepr = sys.repr, outcome.repr
     # partition mean and covar into subsystems A and B
     meanA, meanB = _part_mean(sys, ind)
     covarA, covarB, covarAB = _part_covar(sys, outcome, ind)
     # Block array matmul and broadcasting is incredibly
     # slow, so convert types back to promoted `sys`` and `cond`` types
     meanA′, meanB′ = sys.mean isa Vector{Float64} ? Vector{Float64}.((meanA, meanB)) :
-        (_promote_output_vector(typeof(outcome.mean), meanA, 2*(sys.nmodes - outcome.nmodes)), _promote_output_vector(typeof(outcome.mean), meanB, 2*outcome.nmodes))
+        (_promote_output_vector(typeof(outcome.mean), meanA, 2*(sysrepr.nmodes - outrepr.nmodes)), _promote_output_vector(typeof(outcome.mean), meanB, 2*outrepr.nmodes))
     covarA′, covarB′, covarAB′ = sys.covar isa Matrix{Float64} ? Matrix{Float64}.((covarA, covarB, covarAB)) :
-        (_promote_output_matrix(typeof(outcome.covar), covarA, (2*(sys.nmodes - outcome.nmodes), 2*(sys.nmodes - outcome.nmodes))),
-        _promote_output_matrix(typeof(outcome.covar), covarB, (2*outcome.nmodes, 2*outcome.nmodes)),
-        _promote_output_matrix(typeof(outcome.covar), covarAB, (2*(sys.nmodes - outcome.nmodes), 2*outcome.nmodes)))
+        (_promote_output_matrix(typeof(outcome.covar), covarA, (2*(sysrepr.nmodes - outrepr.nmodes), 2*(sysrepr.nmodes - outrepr.nmodes))),
+        _promote_output_matrix(typeof(outcome.covar), covarB, (2*outrepr.nmodes, 2*outrepr.nmodes)),
+        _promote_output_matrix(typeof(outcome.covar), covarAB, (2*(sysrepr.nmodes - outrepr.nmodes), 2*outrepr.nmodes)))
     # map subsystem A
     meanA′, covarA′ = _generaldyne_map(meanA′, meanB′, covarA′, covarB′, covarAB′, sys, outcome)
-    return GaussianState(meanA′, covarA′, sys.nmodes - outcome.nmodes)
+    return GaussianState(sysrepr - outrepr, meanA′, covarA′)
 end
 
 """
@@ -186,10 +193,12 @@ where ``m`` is the number of modes in subsystem ``B``.
 ## Example
 
 ```jldoctest
-julia> vac = vacuumstate(); coh = coherentstate(1.0-im);
+julia> repr = CanonicalForm(1);
+
+julia> vac = vacuumstate(repr); coh = coherentstate(repr, 1.0-im);
 
 julia> state = vac ⊗ coh ⊗ vac ⊗ coh
-GaussianState for 4 modes.
+GaussianState for 4 modes in CanonicalForm representation.
 mean: 8-element Vector{Float64}:
   0.0
   0.0
@@ -211,9 +220,9 @@ covariance: 8×8 Matrix{Float64}:
 
 julia> gd = Generaldyne(state, coh ⊗ vac ⊗ coh, [1, 3, 4])
 Generaldyne on indices [1, 3, 4]
-system: GaussianState for 4 modes.
+system: GaussianState for 4 modes in CanonicalForm representation.
  (xType: Vector{Float64} | vType: Matrix{Float64})
-outcome: GaussianState for 3 modes.
+outcome: GaussianState for 3 modes in CanonicalForm representation.
  (xType: Vector{Float64} | vType: Matrix{Float64})
 
 julia> prob(gd)
@@ -222,16 +231,17 @@ julia> prob(gd)
 """
 function prob(meas::Generaldyne)
     sys, outcome, ind = meas.system, meas.outcome, meas.indices
+    sysrepr, outrepr = sys.repr, outcome.repr
     # partition mean and covar into subsystems
-    mean′ = BlockedArray(sys.mean, 2*ones(Int,sys.nmodes))
+    mean′ = BlockedArray(sys.mean, 2*ones(Int,sysrepr.nmodes))
     meanB = _part_meanB(mean′, ind)
-    sizeB = (outcome.nmodes, outcome.nmodes)
-    covar′ = BlockedArray(sys.covar, 2*ones(Int,sys.nmodes), 2*ones(Int,sys.nmodes))
-    covarB = _part_covarB(covar′, sys.nmodes, ind, sizeB)
+    sizeB = (outrepr.nmodes, outrepr.nmodes)
+    covar′ = BlockedArray(sys.covar, 2*ones(Int,sysrepr.nmodes), 2*ones(Int,sysrepr.nmodes))
+    covarB = _part_covarB(covar′, sysrepr.nmodes, ind, sizeB)
     # Block array matmul and broadcasting is incredibly
     # slow, so convert types back to promoted `sys`` and `cond`` types
     meanB′ = sys.mean isa Vector{Float64} ? Vector{Float64}(meanB) :
-        _promote_output_vector(typeof(outcome.mean), meanB, 2*outcome.nmodes)
+        _promote_output_vector(typeof(outcome.mean), meanB, 2*outrepr.nmodes)
     covarB′ = sys.covar isa Matrix{Float64} ? Matrix{Float64}(covarB) :
         _promote_output_matrix(typeof(outcome.covar), covarB, sizeB)
     return _prob_formula(meanB′, covarB′, outcome)
@@ -253,39 +263,43 @@ function Base.summary(io::IO, x::Generaldyne)
 end
 
 function _prob_formula(mean, covar, outcome)
+    outrepr = outcome.repr
     # create alloc buffers for matrix multiplication
-    buf = zeros(2*outcome.nmodes)
+    buf = zeros(2*outrepr.nmodes)
     meandiff = outcome.mean .- mean
-    norm = pi^(outcome.nmodes)*sqrt(det(covar .+ outcome.covar))
+    norm = pi^(outrepr.nmodes)*sqrt(det(covar .+ outcome.covar))
     return exp(transpose(meandiff) * mul!(buf, inv(covar .+ outcome.covar), meandiff))/norm
 end
 function _generaldyne_map(meanA, meanB, covarA, covarB, covarAB, sys, outcome)
+    sysrepr, outrepr = sys.repr, outcome.repr
     # create alloc buffers for matrix multiplication
-    meanbuf1, meanbuf2 = zeros(2*outcome.nmodes), zeros(2*(sys.nmodes - outcome.nmodes))
-    covarbuf = zeros(2*(sys.nmodes - outcome.nmodes), 2*(sys.nmodes - outcome.nmodes))
+    meanbuf1, meanbuf2 = zeros(2*outrepr.nmodes), zeros(2*(sysrepr.nmodes - outrepr.nmodes))
+    covarbuf = zeros(2*(sysrepr.nmodes - outrepr.nmodes), 2*(sysrepr.nmodes - outrepr.nmodes))
     # maps subsystem A, which is not measured
     meanA .= meanA .+ mul!(meanbuf2, covarAB, (mul!(meanbuf1, inv(covarB .+ outcome.covar), outcome.mean .- meanB)))
     covarA .= covarA .- mul!(covarbuf, covarAB, (covarB .+ outcome.covar) \ transpose(covarAB))
     return meanA, covarA
 end
 function _part_mean(sys::M, ind::I) where {M,I}
+    sysrepr = sys.repr
     # block mean into its modes
-    mean′ = BlockedArray(sys.mean, 2*ones(Int,sys.nmodes))
-    meanA = _part_meanA(mean′, sys.nmodes, ind)
+    mean′ = BlockedArray(sys.mean, 2*ones(Int,sysrepr.nmodes))
+    meanA = _part_meanA(mean′, sysrepr.nmodes, ind)
     meanB = _part_meanB(mean′, ind)
     return meanA, meanB
 end
 _part_meanA(mean::M, nmodes::N, ind::I) where {M,N,I} = mortar([view(mean, Block(i)) for i in Base.OneTo(nmodes) if !(i in ind)])
 _part_meanB(mean::M, ind::I) where {M,I} = mortar([view(mean, Block(i)) for i in ind])
 function _part_covar(sys::M, outcome::C, ind::I) where {M,C,I}
-    sizeA, sizeB = (sys.nmodes-outcome.nmodes, sys.nmodes-outcome.nmodes), (outcome.nmodes, outcome.nmodes)
-    sizeAB = (sys.nmodes-outcome.nmodes, outcome.nmodes)
+    sysrepr, outrepr = sys.repr, outcome.repr
+    sizeA, sizeB = (sysrepr.nmodes-outrepr.nmodes, sysrepr.nmodes-outrepr.nmodes), (outrepr.nmodes, outrepr.nmodes)
+    sizeAB = (sysrepr.nmodes-outrepr.nmodes, outrepr.nmodes)
     # loop through entire Gaussian system, writing quadratures to B if
     # index is specified in `ind` argument
-    covar′ = BlockedArray(sys.covar, 2*ones(Int,sys.nmodes), 2*ones(Int,sys.nmodes))
-    covarA = _part_covarA(covar′, sys.nmodes, ind, sizeA)
-    covarB = _part_covarB(covar′, sys.nmodes, ind, sizeB)
-    covarAB = _part_covarAB(covar′, sys.nmodes, ind, sizeAB)
+    covar′ = BlockedArray(sys.covar, 2*ones(Int,sysrepr.nmodes), 2*ones(Int,sysrepr.nmodes))
+    covarA = _part_covarA(covar′, sysrepr.nmodes, ind, sizeA)
+    covarB = _part_covarB(covar′, sysrepr.nmodes, ind, sizeB)
+    covarAB = _part_covarAB(covar′, sysrepr.nmodes, ind, sizeAB)
     return covarA, covarB, covarAB
 end
 function _part_covarA(covar::C, nmodes::N, ind::I, size::S) where {C,N,I,S}

--- a/src/randoms.jl
+++ b/src/randoms.jl
@@ -1,7 +1,7 @@
 """
-    randstate([Tm=Vector{Float64}, Tc=Matrix{Float64},] nmodes<:Int; pure=false)
+    randstate([Tm=Vector{Float64}, Tc=Matrix{Float64},] basis::SymplecticBasis; pure=false)
 
-Calculate a random Gaussian state.
+Calculate a random Gaussian state in symplectic representation defined by `basis`.
 """
 function randstate(::Type{Tm}, ::Type{Tc}, basis::SymplecticBasis{N}; pure = false) where {Tm,Tc,N<:Int}
     mean, covar = _randstate(basis, pure)
@@ -32,9 +32,9 @@ function _randstate(basis::QuadPairBasis{N}, pure) where {N<:Int}
 end
 
 """
-    randunitary([Td=Vector{Float64}, Ts=Matrix{Float64},] nmodes<:Int; passive=false)
+    randunitary([Td=Vector{Float64}, Ts=Matrix{Float64},] basis::SymplecticBasis; passive=false)
 
-Calculate a random Gaussian unitary operator.
+Calculate a random Gaussian unitary operator in symplectic representation defined by `basis`.
 """
 function randunitary(::Type{Td}, ::Type{Ts}, basis::SymplecticBasis{N}; passive = false) where {Td,Ts,N<:Int}
     disp, symp = _randunitary(basis, passive)
@@ -53,9 +53,9 @@ function _randunitary(basis::SymplecticBasis{N}, passive) where {N<:Int}
 end
 
 """
-    randchannel([Td=Vector{Float64}, Tt=Matrix{Float64},] nmodes<:Int)
+    randchannel([Td=Vector{Float64}, Tt=Matrix{Float64},] basis::SymplecticBasis)
 
-Calculate a random Gaussian channel.
+Calculate a random Gaussian channel in symplectic representation defined by `basis`.
 """
 function randchannel(::Type{Td}, ::Type{Tt}, basis::SymplecticBasis{N}) where {Td,Tt,N<:Int}
     disp, transform, noise = _randchannel(basis)
@@ -80,9 +80,9 @@ function _randchannel(basis::SymplecticBasis{N}) where {N<:Int}
 end
 
 """
-    randsymplectic([T=Matrix{Float64},] nmodes<:Int, passive=false)
+    randsymplectic([T=Matrix{Float64},] basis::SymplecticBasis, passive=false)
 
-Calculate a random symplectic matrix of size `2*nmodes x 2*nmodes`.
+Calculate a random symplectic matrix in symplectic representation defined by `basis`.
 """
 function randsymplectic(basis::QuadPairBasis{N}; passive = false) where {N<:Int}
     nmodes = basis.nmodes

--- a/src/randoms.jl
+++ b/src/randoms.jl
@@ -3,20 +3,20 @@
 
 Calculate a random Gaussian state.
 """
-function randstate(::Type{Tm}, ::Type{Tc}, repr::SymplecticRepr{N}; pure = false) where {Tm,Tc,N<:Int}
-    mean, covar = _randstate(repr, pure)
-    return GaussianState(repr, Tm(mean), Tc(covar))
+function randstate(::Type{Tm}, ::Type{Tc}, basis::SymplecticBasis{N}; pure = false) where {Tm,Tc,N<:Int}
+    mean, covar = _randstate(basis, pure)
+    return GaussianState(basis, Tm(mean), Tc(covar))
 end
-randstate(::Type{T}, repr::SymplecticRepr{N}; pure = false) where {T,N<:Int} = randstate(T,T,repr,pure=pure)
-function randstate(repr::SymplecticRepr{N}; pure = false) where {N<:Int}
-    mean, covar = _randstate(repr, pure)
-    return GaussianState(repr, mean, covar)
+randstate(::Type{T}, basis::SymplecticBasis{N}; pure = false) where {T,N<:Int} = randstate(T,T,basis,pure=pure)
+function randstate(basis::SymplecticBasis{N}; pure = false) where {N<:Int}
+    mean, covar = _randstate(basis, pure)
+    return GaussianState(basis, mean, covar)
 end
-function _randstate(repr::CanonicalForm{N}, pure) where {N<:Int}
-    nmodes = repr.nmodes
+function _randstate(basis::QuadPairBasis{N}, pure) where {N<:Int}
+    nmodes = basis.nmodes
     mean = randn(2*nmodes)
     covar = zeros(2*nmodes, 2*nmodes)
-    symp = randsymplectic(repr)
+    symp = randsymplectic(basis)
     # generate pure Gaussian state
     if pure
         mul!(covar, symp, symp')
@@ -36,19 +36,19 @@ end
 
 Calculate a random Gaussian unitary operator.
 """
-function randunitary(::Type{Td}, ::Type{Ts}, repr::SymplecticRepr{N}; passive = false) where {Td,Ts,N<:Int}
-    disp, symp = _randunitary(repr, passive)
-    return GaussianUnitary(repr, Td(disp), Ts(symp))
+function randunitary(::Type{Td}, ::Type{Ts}, basis::SymplecticBasis{N}; passive = false) where {Td,Ts,N<:Int}
+    disp, symp = _randunitary(basis, passive)
+    return GaussianUnitary(basis, Td(disp), Ts(symp))
 end
-randunitary(::Type{T}, repr::SymplecticRepr{N}; passive = false) where {T,N<:Int} = randunitary(T,T,repr; passive = passive)
-function randunitary(repr::SymplecticRepr{N}; passive = false) where {N<:Int}
-    disp, symp = _randunitary(repr, passive)
-    return GaussianUnitary(repr, disp, symp)
+randunitary(::Type{T}, basis::SymplecticBasis{N}; passive = false) where {T,N<:Int} = randunitary(T,T,basis; passive = passive)
+function randunitary(basis::SymplecticBasis{N}; passive = false) where {N<:Int}
+    disp, symp = _randunitary(basis, passive)
+    return GaussianUnitary(basis, disp, symp)
 end
-function _randunitary(repr::SymplecticRepr{N}, passive) where {N<:Int}
-    nmodes = repr.nmodes
+function _randunitary(basis::SymplecticBasis{N}, passive) where {N<:Int}
+    nmodes = basis.nmodes
     disp = rand(2*nmodes)
-    symp = randsymplectic(repr, passive = passive)
+    symp = randsymplectic(basis, passive = passive)
     return disp, symp
 end
 
@@ -57,21 +57,21 @@ end
 
 Calculate a random Gaussian channel.
 """
-function randchannel(::Type{Td}, ::Type{Tt}, repr::SymplecticRepr{N}) where {Td,Tt,N<:Int}
-    disp, transform, noise = _randchannel(repr)
-    return GaussianChannel(repr, Td(disp), Tt(transform), Tt(noise))
+function randchannel(::Type{Td}, ::Type{Tt}, basis::SymplecticBasis{N}) where {Td,Tt,N<:Int}
+    disp, transform, noise = _randchannel(basis)
+    return GaussianChannel(basis, Td(disp), Tt(transform), Tt(noise))
 end
-randchannel(::Type{T}, repr::SymplecticRepr{N}) where {T,N<:Int} = randchannel(T,T,repr)
-function randchannel(repr::SymplecticRepr{N}) where {N<:Int}
-    disp, transform, noise = _randchannel(repr)
-    return GaussianChannel(repr, disp, transform, noise)
+randchannel(::Type{T}, basis::SymplecticBasis{N}) where {T,N<:Int} = randchannel(T,T,basis)
+function randchannel(basis::SymplecticBasis{N}) where {N<:Int}
+    disp, transform, noise = _randchannel(basis)
+    return GaussianChannel(basis, disp, transform, noise)
 end
-function _randchannel(repr::SymplecticRepr{N}) where {N<:Int}
-    nmodes = repr.nmodes
+function _randchannel(basis::SymplecticBasis{N}) where {N<:Int}
+    nmodes = basis.nmodes
     disp = randn(2*nmodes)
     # generate symplectic matrix describing the evolution of the system with N modes
     # and environment with 2N modes
-    symp = randsymplectic(typeof(repr)(3*nmodes))
+    symp = randsymplectic(typeof(basis)(3*nmodes))
     transform, B = symp[1:2*nmodes, 1:2*nmodes], @view(symp[1:2*nmodes, 2*nmodes+1:6*nmodes])
     # generate noise matrix from evolution of environment
     noise = zeros(2*nmodes, 2*nmodes)
@@ -84,15 +84,15 @@ end
 
 Calculate a random symplectic matrix of size `2*nmodes x 2*nmodes`.
 """
-function randsymplectic(repr::CanonicalForm{N}; passive = false) where {N<:Int}
-    nmodes = repr.nmodes
+function randsymplectic(basis::QuadPairBasis{N}; passive = false) where {N<:Int}
+    nmodes = basis.nmodes
     # generate random orthogonal symplectic matrix
-    O = _rand_orthogonal_symplectic(repr)
+    O = _rand_orthogonal_symplectic(basis)
     if passive
         return O
     end
     # instead generate random active symplectic matrix
-    O′ = _rand_orthogonal_symplectic(repr)
+    O′ = _rand_orthogonal_symplectic(basis)
     # direct sum of symplectic matrices for single-mode squeeze transformations
     rs = rand(nmodes)
     squeezes = zeros(2*nmodes, 2*nmodes)
@@ -103,16 +103,16 @@ function randsymplectic(repr::CanonicalForm{N}; passive = false) where {N<:Int}
     end
     return O * squeezes * O′
 end
-function randsymplectic(::Type{T}, repr::CanonicalForm{N}; passive = false) where {T, N<:Int} 
-    symp = randsymplectic(repr, passive = passive)
+function randsymplectic(::Type{T}, basis::QuadPairBasis{N}; passive = false) where {T, N<:Int} 
+    symp = randsymplectic(basis, passive = passive)
     return T(symp)
 end
 
 # Generates random orthogonal symplectic matrix by blocking real
 # and imaginary parts of a random unitary matrix
-function _rand_orthogonal_symplectic(repr::CanonicalForm{N}) where {N<:Int}
-    nmodes = repr.nmodes
-    U = _rand_unitary(repr)
+function _rand_orthogonal_symplectic(basis::QuadPairBasis{N}) where {N<:Int}
+    nmodes = basis.nmodes
+    U = _rand_unitary(basis)
     O = zeros(2*nmodes, 2*nmodes)
     @inbounds for i in Base.OneTo(nmodes), j in Base.OneTo(nmodes)
         val = U[i,j]
@@ -126,8 +126,8 @@ end
 # Generates unitary matrix randomly distributed over Haar measure;
 # see https://arxiv.org/abs/math-ph/0609050 for algorithm.
 # This approach is faster and creates less allocations than rand(Haar(2), nmodes) from RandomMatrices.jl
-function _rand_unitary(repr::CanonicalForm{N}) where {N<:Int}
-    nmodes = repr.nmodes
+function _rand_unitary(basis::QuadPairBasis{N}) where {N<:Int}
+    nmodes = basis.nmodes
     M = rand(ComplexF64, nmodes, nmodes) ./ sqrt(2.0)
     q, r = qr(M)
     d = diagm([r[i, i] / abs(r[i, i]) for i in Base.OneTo(nmodes)])

--- a/src/randoms.jl
+++ b/src/randoms.jl
@@ -3,19 +3,20 @@
 
 Calculate a random Gaussian state.
 """
-function randstate(::Type{Tm}, ::Type{Tc}, nmodes::N; pure = false) where {Tm,Tc,N<:Int}
-    mean, covar = _randstate_fields(nmodes, pure)
-    return GaussianState(Tm(mean), Tc(covar), nmodes)
+function randstate(::Type{Tm}, ::Type{Tc}, repr::SymplecticRepr{N}; pure = false) where {Tm,Tc,N<:Int}
+    mean, covar = _randstate(repr, pure)
+    return GaussianState(repr, Tm(mean), Tc(covar))
 end
-randstate(::Type{T}, nmodes::N; pure = false) where {T,N<:Int} = randstate(T,T,nmodes,pure=pure)
-function randstate(nmodes::N; pure = false) where {N<:Int}
-    mean, covar = _randstate_fields(nmodes, pure)
-    return GaussianState(mean, covar, nmodes)
+randstate(::Type{T}, repr::SymplecticRepr{N}; pure = false) where {T,N<:Int} = randstate(T,T,repr,pure=pure)
+function randstate(repr::SymplecticRepr{N}; pure = false) where {N<:Int}
+    mean, covar = _randstate(repr, pure)
+    return GaussianState(repr, mean, covar)
 end
-function _randstate_fields(nmodes::N, pure) where {N<:Int}
+function _randstate(repr::CanonicalForm{N}, pure) where {N<:Int}
+    nmodes = repr.nmodes
     mean = randn(2*nmodes)
     covar = zeros(2*nmodes, 2*nmodes)
-    symp = randsymplectic(nmodes)
+    symp = randsymplectic(repr)
     # generate pure Gaussian state
     if pure
         mul!(covar, symp, symp')
@@ -35,18 +36,19 @@ end
 
 Calculate a random Gaussian unitary operator.
 """
-function randunitary(::Type{Td}, ::Type{Ts}, nmodes::N; passive = false) where {Td,Ts,N}
-    disp, symp = _randunitary_fields(nmodes, passive)
-    return GaussianUnitary(Td(disp), Ts(symp))
+function randunitary(::Type{Td}, ::Type{Ts}, repr::SymplecticRepr{N}; passive = false) where {Td,Ts,N<:Int}
+    disp, symp = _randunitary(repr, passive)
+    return GaussianUnitary(repr, Td(disp), Ts(symp))
 end
-randunitary(::Type{T}, nmodes::N; passive = false) where {T,N<:Int} = randunitary(T,T,nmodes; passive = passive)
-function randunitary(nmodes::N; passive = false) where {N<:Int}
-    disp, symp = _randunitary_fields(nmodes, passive)
-    return GaussianUnitary(disp, symp)
+randunitary(::Type{T}, repr::SymplecticRepr{N}; passive = false) where {T,N<:Int} = randunitary(T,T,repr; passive = passive)
+function randunitary(repr::SymplecticRepr{N}; passive = false) where {N<:Int}
+    disp, symp = _randunitary(repr, passive)
+    return GaussianUnitary(repr, disp, symp)
 end
-function _randunitary_fields(nmodes::N, passive) where {N<:Int}
+function _randunitary(repr::SymplecticRepr{N}, passive) where {N<:Int}
+    nmodes = repr.nmodes
     disp = rand(2*nmodes)
-    symp = randsymplectic(nmodes, passive = passive)
+    symp = randsymplectic(repr, passive = passive)
     return disp, symp
 end
 
@@ -55,20 +57,21 @@ end
 
 Calculate a random Gaussian channel.
 """
-function randchannel(::Type{Td}, ::Type{Tt}, nmodes::N) where {Td,Tt,N<:Int}
-    disp, transform, noise = _randchannel(nmodes)
-    return GaussianChannel(Td(disp), Tt(transform), Tt(noise), nmodes)
+function randchannel(::Type{Td}, ::Type{Tt}, repr::SymplecticRepr{N}) where {Td,Tt,N<:Int}
+    disp, transform, noise = _randchannel(repr)
+    return GaussianChannel(repr, Td(disp), Tt(transform), Tt(noise))
 end
-randchannel(::Type{T}, nmodes::N) where {T,N<:Int} = randchannel(T,T,nmodes)
-function randchannel(nmodes::N) where {N<:Int}
-    disp, transform, noise = _randchannel(nmodes)
-    return GaussianChannel(disp, transform, noise, nmodes)
+randchannel(::Type{T}, repr::SymplecticRepr{N}) where {T,N<:Int} = randchannel(T,T,repr)
+function randchannel(repr::SymplecticRepr{N}) where {N<:Int}
+    disp, transform, noise = _randchannel(repr)
+    return GaussianChannel(repr, disp, transform, noise)
 end
-function _randchannel(nmodes::N) where {N<:Int}
+function _randchannel(repr::SymplecticRepr{N}) where {N<:Int}
+    nmodes = repr.nmodes
     disp = randn(2*nmodes)
     # generate symplectic matrix describing the evolution of the system with N modes
     # and environment with 2N modes
-    symp = randsymplectic(3*nmodes)
+    symp = randsymplectic(typeof(repr)(3*nmodes))
     transform, B = symp[1:2*nmodes, 1:2*nmodes], @view(symp[1:2*nmodes, 2*nmodes+1:6*nmodes])
     # generate noise matrix from evolution of environment
     noise = zeros(2*nmodes, 2*nmodes)
@@ -81,14 +84,15 @@ end
 
 Calculate a random symplectic matrix of size `2*nmodes x 2*nmodes`.
 """
-function randsymplectic(nmodes::N; passive = false) where {N<:Int}
+function randsymplectic(repr::CanonicalForm{N}; passive = false) where {N<:Int}
+    nmodes = repr.nmodes
     # generate random orthogonal symplectic matrix
-    O = _rand_orthogonal_symplectic(nmodes)
+    O = _rand_orthogonal_symplectic(repr)
     if passive
         return O
     end
     # instead generate random active symplectic matrix
-    O′ = _rand_orthogonal_symplectic(nmodes)
+    O′ = _rand_orthogonal_symplectic(repr)
     # direct sum of symplectic matrices for single-mode squeeze transformations
     rs = rand(nmodes)
     squeezes = zeros(2*nmodes, 2*nmodes)
@@ -99,15 +103,16 @@ function randsymplectic(nmodes::N; passive = false) where {N<:Int}
     end
     return O * squeezes * O′
 end
-function randsymplectic(::Type{T}, nmodes::N; passive = false) where {T, N<:Int} 
-    symp = randsymplectic(nmodes, passive = passive)
+function randsymplectic(::Type{T}, repr::CanonicalForm{N}; passive = false) where {T, N<:Int} 
+    symp = randsymplectic(repr, passive = passive)
     return T(symp)
 end
 
 # Generates random orthogonal symplectic matrix by blocking real
 # and imaginary parts of a random unitary matrix
-function _rand_orthogonal_symplectic(nmodes::N) where {N<:Int}
-    U = _rand_unitary(nmodes)
+function _rand_orthogonal_symplectic(repr::CanonicalForm{N}) where {N<:Int}
+    nmodes = repr.nmodes
+    U = _rand_unitary(repr)
     O = zeros(2*nmodes, 2*nmodes)
     @inbounds for i in Base.OneTo(nmodes), j in Base.OneTo(nmodes)
         val = U[i,j]
@@ -120,10 +125,11 @@ function _rand_orthogonal_symplectic(nmodes::N) where {N<:Int}
 end
 # Generates unitary matrix randomly distributed over Haar measure;
 # see https://arxiv.org/abs/math-ph/0609050 for algorithm.
-# This approach is faster and creates less allocations than rand(Haar(2), size) from RandomMatrices.jl
-function _rand_unitary(size::N) where {N<:Int}
-    M = rand(ComplexF64, size, size) ./ sqrt(2.0)
+# This approach is faster and creates less allocations than rand(Haar(2), nmodes) from RandomMatrices.jl
+function _rand_unitary(repr::CanonicalForm{N}) where {N<:Int}
+    nmodes = repr.nmodes
+    M = rand(ComplexF64, nmodes, nmodes) ./ sqrt(2.0)
     q, r = qr(M)
-    d = diagm([r[i, i] / abs(r[i, i]) for i in Base.OneTo(size)])
+    d = diagm([r[i, i] / abs(r[i, i]) for i in Base.OneTo(nmodes)])
     return q * d
 end

--- a/src/states.jl
+++ b/src/states.jl
@@ -19,8 +19,8 @@ matrix ``\\mathbf{V}``, expressed respectively as follows:
 ## Example
 
 ```jldoctest
-julia> vacuumstate(CanonicalForm(1))
-GaussianState for 1 mode in CanonicalForm representation.
+julia> vacuumstate(QuadPairBasis(1))
+GaussianState for 1 mode in QuadPairBasis representation.
 mean: 2-element Vector{Float64}:
  0.0
  0.0
@@ -29,17 +29,17 @@ covariance: 2×2 Matrix{Float64}:
  0.0  1.0
 ```
 """
-function vacuumstate(::Type{Tm}, ::Type{Tc}, repr::SymplecticRepr{N}) where {Tm,Tc,N<:Int}
-    mean, covar = _vacuumstate(repr)
-    return GaussianState(repr, Tm(mean), Tc(covar))
+function vacuumstate(::Type{Tm}, ::Type{Tc}, basis::SymplecticBasis{N}) where {Tm,Tc,N<:Int}
+    mean, covar = _vacuumstate(basis)
+    return GaussianState(basis, Tm(mean), Tc(covar))
 end
-vacuumstate(::Type{T}, repr::SymplecticRepr{N}) where {T,N<:Int} = vacuumstate(T, T, repr)
-function vacuumstate(repr::SymplecticRepr{N}) where {N<:Int}
-    mean, covar = _vacuumstate(repr)
-    return GaussianState(repr, mean, covar)
+vacuumstate(::Type{T}, basis::SymplecticBasis{N}) where {T,N<:Int} = vacuumstate(T, T, basis)
+function vacuumstate(basis::SymplecticBasis{N}) where {N<:Int}
+    mean, covar = _vacuumstate(basis)
+    return GaussianState(basis, mean, covar)
 end
-function _vacuumstate(repr::SymplecticRepr{N}) where {N<:Int}
-    nmodes = repr.nmodes
+function _vacuumstate(basis::SymplecticBasis{N}) where {N<:Int}
+    nmodes = basis.nmodes
     mean = zeros(2*nmodes)
     covar = Matrix{Float64}(I, 2*nmodes, 2*nmodes)
     return mean, covar
@@ -64,8 +64,8 @@ matrix ``\\mathbf{V}``, expressed respectively as follows:
 ## Example
 
 ```jldoctest
-julia> thermalstate(CanonicalForm(1), 4)
-GaussianState for 1 mode in CanonicalForm representation.
+julia> thermalstate(QuadPairBasis(1), 4)
+GaussianState for 1 mode in QuadPairBasis representation.
 mean: 2-element Vector{Float64}:
  0.0
  0.0
@@ -74,23 +74,23 @@ covariance: 2×2 Matrix{Float64}:
  0.0  4.5
 ```
 """
-function thermalstate(::Type{Tm}, ::Type{Tc}, repr::SymplecticRepr{N}, photons::P) where {Tm,Tc,N<:Int,P}
-    mean, covar = _thermalstate(repr, photons)
-    return GaussianState(repr, Tm(mean), Tc(covar))
+function thermalstate(::Type{Tm}, ::Type{Tc}, basis::SymplecticBasis{N}, photons::P) where {Tm,Tc,N<:Int,P}
+    mean, covar = _thermalstate(basis, photons)
+    return GaussianState(basis, Tm(mean), Tc(covar))
 end
-thermalstate(::Type{T}, repr::SymplecticRepr{N}, photons::P) where {T,N<:Int,P} = thermalstate(T, T, repr, photons)
-function thermalstate(repr::SymplecticRepr{N}, photons::P) where {N<:Int,P}
-    mean, covar = _thermalstate(repr, photons)
-    return GaussianState(repr, mean, covar)
+thermalstate(::Type{T}, basis::SymplecticBasis{N}, photons::P) where {T,N<:Int,P} = thermalstate(T, T, basis, photons)
+function thermalstate(basis::SymplecticBasis{N}, photons::P) where {N<:Int,P}
+    mean, covar = _thermalstate(basis, photons)
+    return GaussianState(basis, mean, covar)
 end
-function _thermalstate(repr::CanonicalForm{N}, photons::P) where {N<:Int,P<:Int}
-    nmodes = repr.nmodes
+function _thermalstate(basis::QuadPairBasis{N}, photons::P) where {N<:Int,P<:Int}
+    nmodes = basis.nmodes
     mean = zeros(2*nmodes)
     covar = Matrix{Float64}((photons + 1/2) * I, 2*nmodes, 2*nmodes)
     return mean, covar
 end
-function _thermalstate(repr::CanonicalForm{N}, photons::P) where {N<:Int,P<:Vector}
-    nmodes = repr.nmodes
+function _thermalstate(basis::QuadPairBasis{N}, photons::P) where {N<:Int,P<:Vector}
+    nmodes = basis.nmodes
     mean = zeros(2*nmodes)
     covar = zeros(2*nmodes, 2*nmodes)
     @inbounds for i in Base.OneTo(nmodes)
@@ -121,8 +121,8 @@ matrix ``\\mathbf{V}``, expressed respectively as follows:
 ## Example
 
 ```jldoctest
-julia> coherentstate(CanonicalForm(1), 1.0+im)
-GaussianState for 1 mode in CanonicalForm representation.
+julia> coherentstate(QuadPairBasis(1), 1.0+im)
+GaussianState for 1 mode in QuadPairBasis representation.
 mean: 2-element Vector{Float64}:
  1.4142135623730951
  1.4142135623730951
@@ -131,23 +131,23 @@ covariance: 2×2 Matrix{Float64}:
  0.0  1.0
 ```
 """
-function coherentstate(::Type{Tm}, ::Type{Tc}, repr::SymplecticRepr{N}, alpha::A) where {Tm,Tc,N<:Int,A}
-    mean, covar = _coherentstate(repr, alpha)
-    return GaussianState(repr, Tm(mean), Tc(covar))
+function coherentstate(::Type{Tm}, ::Type{Tc}, basis::SymplecticBasis{N}, alpha::A) where {Tm,Tc,N<:Int,A}
+    mean, covar = _coherentstate(basis, alpha)
+    return GaussianState(basis, Tm(mean), Tc(covar))
 end
-coherentstate(::Type{T}, repr::SymplecticRepr{N}, alpha::A) where {T,N<:Int,A} = coherentstate(T, T, repr, alpha)
-function coherentstate(repr::SymplecticRepr{N}, alpha::A) where {N<:Int,A}
-    mean, covar = _coherentstate(repr, alpha)
-    return GaussianState(repr, mean, covar)
+coherentstate(::Type{T}, basis::SymplecticBasis{N}, alpha::A) where {T,N<:Int,A} = coherentstate(T, T, basis, alpha)
+function coherentstate(basis::SymplecticBasis{N}, alpha::A) where {N<:Int,A}
+    mean, covar = _coherentstate(basis, alpha)
+    return GaussianState(basis, mean, covar)
 end
-function _coherentstate(repr::CanonicalForm{N}, alpha::A) where {N<:Int,A<:Number}
-    nmodes = repr.nmodes
+function _coherentstate(basis::QuadPairBasis{N}, alpha::A) where {N<:Int,A<:Number}
+    nmodes = basis.nmodes
     mean = repeat([sqrt(2)*real(alpha), sqrt(2)*imag(alpha)], nmodes)
     covar = Matrix{Float64}(I, 2*nmodes, 2*nmodes)
     return mean, covar
 end
-function _coherentstate(repr::CanonicalForm{N}, alpha::A) where {N<:Int,A<:Vector}
-    nmodes = repr.nmodes
+function _coherentstate(basis::QuadPairBasis{N}, alpha::A) where {N<:Int,A<:Vector}
+    nmodes = basis.nmodes
     mean = sqrt(2) * reinterpret(Float64, alpha)
     covar = Matrix{Float64}(I, 2*nmodes, 2*nmodes)
     return mean, covar
@@ -177,8 +177,8 @@ where ``\\mathbf{R}(\\theta)`` is the rotation matrix.
 ## Example
 
 ```jldoctest
-julia> squeezedstate(CanonicalForm(1), 0.5, pi/4)
-GaussianState for 1 mode in CanonicalForm representation.
+julia> squeezedstate(QuadPairBasis(1), 0.5, pi/4)
+GaussianState for 1 mode in QuadPairBasis representation.
 mean: 2-element Vector{Float64}:
  0.0
  0.0
@@ -187,17 +187,17 @@ covariance: 2×2 Matrix{Float64}:
  0.415496  1.18704
 ```
 """
-function squeezedstate(::Type{Tm}, ::Type{Tc}, repr::SymplecticRepr{N}, r::R, theta::R) where {Tm,Tc,N<:Int,R}
-    mean, covar = _squeezedstate(repr, r, theta)
-    return GaussianState(repr, Tm(mean), Tc(covar))
+function squeezedstate(::Type{Tm}, ::Type{Tc}, basis::SymplecticBasis{N}, r::R, theta::R) where {Tm,Tc,N<:Int,R}
+    mean, covar = _squeezedstate(basis, r, theta)
+    return GaussianState(basis, Tm(mean), Tc(covar))
 end
-squeezedstate(::Type{T}, repr::SymplecticRepr{N}, r::R, theta::R) where {T,N<:Int,R} = squeezedstate(T, T, repr, r, theta)
-function squeezedstate(repr::SymplecticRepr{N}, r::R, theta::R) where {N<:Int,R}
-    mean, covar = _squeezedstate(repr, r, theta)
-    return GaussianState(repr, mean, covar)
+squeezedstate(::Type{T}, basis::SymplecticBasis{N}, r::R, theta::R) where {T,N<:Int,R} = squeezedstate(T, T, basis, r, theta)
+function squeezedstate(basis::SymplecticBasis{N}, r::R, theta::R) where {N<:Int,R}
+    mean, covar = _squeezedstate(basis, r, theta)
+    return GaussianState(basis, mean, covar)
 end
-function _squeezedstate(repr::CanonicalForm{N}, r::R, theta::R) where {N<:Int,R<:Real}
-    nmodes = repr.nmodes
+function _squeezedstate(basis::QuadPairBasis{N}, r::R, theta::R) where {N<:Int,R<:Real}
+    nmodes = basis.nmodes
     mean = zeros(2*nmodes)
     covar = zeros(2*nmodes, 2*nmodes)
     cr, sr = cosh(2*r), sinh(2*r)
@@ -210,8 +210,8 @@ function _squeezedstate(repr::CanonicalForm{N}, r::R, theta::R) where {N<:Int,R<
     end
     return mean, covar
 end
-function _squeezedstate(repr::CanonicalForm{N}, r::R, theta::R) where {N<:Int,R<:Vector}
-    nmodes = repr.nmodes
+function _squeezedstate(basis::QuadPairBasis{N}, r::R, theta::R) where {N<:Int,R<:Vector}
+    nmodes = basis.nmodes
     mean = zeros(2*nmodes)
     covar = zeros(2*nmodes, 2*nmodes)
     @inbounds for i in Base.OneTo(nmodes)
@@ -251,8 +251,8 @@ where ``\\mathbf{R}(\\theta)`` is the rotation matrix.
 ## Example
 
 ```jldoctest
-julia> eprstate(CanonicalForm(2), 0.5, pi/4)
-GaussianState for 2 modes in CanonicalForm representation.
+julia> eprstate(QuadPairBasis(2), 0.5, pi/4)
+GaussianState for 2 modes in QuadPairBasis representation.
 mean: 4-element Vector{Float64}:
  0.0
  0.0
@@ -265,17 +265,17 @@ covariance: 4×4 Matrix{Float64}:
  0.415496  -0.415496  0.0        0.77154
 ```
 """
-function eprstate(::Type{Tm}, ::Type{Tc}, repr::SymplecticRepr{N}, r::R, theta::R) where {Tm,Tc,N<:Int,R}
-    mean, covar = _eprstate(repr, r, theta)
-    return GaussianState(repr, Tm(mean), Tc(covar))
+function eprstate(::Type{Tm}, ::Type{Tc}, basis::SymplecticBasis{N}, r::R, theta::R) where {Tm,Tc,N<:Int,R}
+    mean, covar = _eprstate(basis, r, theta)
+    return GaussianState(basis, Tm(mean), Tc(covar))
 end
-eprstate(::Type{T}, repr::SymplecticRepr{N}, r::R, theta::R) where {T,N<:Int,R} = eprstate(T, T, repr, r, theta)
-function eprstate(repr::SymplecticRepr{N}, r::R, theta::R) where {N<:Int,R}
-    mean, covar = _eprstate(repr, r, theta)
-    return GaussianState(repr, mean, covar)
+eprstate(::Type{T}, basis::SymplecticBasis{N}, r::R, theta::R) where {T,N<:Int,R} = eprstate(T, T, basis, r, theta)
+function eprstate(basis::SymplecticBasis{N}, r::R, theta::R) where {N<:Int,R}
+    mean, covar = _eprstate(basis, r, theta)
+    return GaussianState(basis, mean, covar)
 end
-function _eprstate(repr::CanonicalForm{N}, r::R, theta::R) where {N<:Int,R<:Real}
-    nmodes = repr.nmodes
+function _eprstate(basis::QuadPairBasis{N}, r::R, theta::R) where {N<:Int,R<:Real}
+    nmodes = basis.nmodes
     mean = zeros(2*nmodes)
     cr, sr = (1/2)*cosh(2*r), (1/2)*sinh(2*r)
     ct, st = cos(theta), sin(theta)
@@ -299,8 +299,8 @@ function _eprstate(repr::CanonicalForm{N}, r::R, theta::R) where {N<:Int,R<:Real
     end
     return mean, covar
 end
-function _eprstate(repr::CanonicalForm{N}, r::R, theta::R) where {N<:Int,R<:Vector}
-    nmodes = repr.nmodes
+function _eprstate(basis::QuadPairBasis{N}, r::R, theta::R) where {N<:Int,R<:Vector}
+    nmodes = basis.nmodes
     mean = zeros(2*nmodes)
     covar = zeros(2*nmodes, 2*nmodes)
     @inbounds for i in Base.OneTo(Int(nmodes/2))
@@ -337,10 +337,10 @@ tensor product of Gaussian states, which can also be called with `⊗`.
 
 ## Example
 ```jldoctest
-julia> repr = CanonicalForm(1);
+julia> basis = QuadPairBasis(1);
 
-julia> coherentstate(repr, 1.0+im) ⊗ thermalstate(repr, 2)
-GaussianState for 2 modes in CanonicalForm representation.
+julia> coherentstate(basis, 1.0+im) ⊗ thermalstate(basis, 2)
+GaussianState for 2 modes in QuadPairBasis representation.
 mean: 4-element Vector{Float64}:
  1.4142135623730951
  1.4142135623730951
@@ -354,19 +354,19 @@ covariance: 4×4 Matrix{Float64}:
 ```
 """
 function tensor(::Type{Tm}, ::Type{Tc}, state1::GaussianState, state2::GaussianState) where {Tm,Tc}
-    typeof(state1.repr) == typeof(state2.repr) || throw(ArgumentError(SYMPLECTIC_ERROR))
+    typeof(state1.basis) == typeof(state2.basis) || throw(ArgumentError(SYMPLECTIC_ERROR))
     mean, covar = _tensor(state1, state2)
-    return GaussianState(state1.repr + state2.repr, Tm(mean), Tc(covar))
+    return GaussianState(state1.basis + state2.basis, Tm(mean), Tc(covar))
 end
 tensor(::Type{T}, state1::GaussianState, state2::GaussianState) where {T} = tensor(T, T, state1, state2)
 function tensor(state1::GaussianState, state2::GaussianState)
-    typeof(state1.repr) == typeof(state2.repr) || throw(ArgumentError(SYMPLECTIC_ERROR))
+    typeof(state1.basis) == typeof(state2.basis) || throw(ArgumentError(SYMPLECTIC_ERROR))
     mean, covar = _tensor(state1, state2)
-    return GaussianState(state1.repr + state2.repr, mean, covar)
+    return GaussianState(state1.basis + state2.basis, mean, covar)
 end
 function _tensor(state1::GaussianState, state2::GaussianState)
     mean1, mean2 = state1.mean, state2.mean
-    repr1, repr2 = state1.repr, state2.repr
+    repr1, repr2 = state1.basis, state2.basis
     length1, length2 = 2*repr1.nmodes, 2*repr2.nmodes
     slengths = length1 + length2
     covar1, covar2 = state1.covar, state2.covar
@@ -403,10 +403,10 @@ indicated by `indices`.
 
 ## Example
 ```jldoctest
-julia> repr = CanonicalForm(1);
+julia> basis = QuadPairBasis(1);
 
-julia> state = coherentstate(repr, 1.0+im) ⊗ thermalstate(repr, 2) ⊗ squeezedstate(repr, 3.0, pi/4)
-GaussianState for 3 modes in CanonicalForm representation.
+julia> state = coherentstate(basis, 1.0+im) ⊗ thermalstate(basis, 2) ⊗ squeezedstate(basis, 3.0, pi/4)
+GaussianState for 3 modes in QuadPairBasis representation.
 mean: 6-element Vector{Float64}:
  1.4142135623730951
  1.4142135623730951
@@ -423,7 +423,7 @@ covariance: 6×6 Matrix{Float64}:
  0.0  0.0  0.0  0.0  71.3164  172.174
 
 julia> ptrace(state, 2)
-GaussianState for 1 mode in CanonicalForm representation.
+GaussianState for 1 mode in QuadPairBasis representation.
 mean: 2-element Vector{Float64}:
  0.0
  0.0
@@ -432,7 +432,7 @@ covariance: 2×2 Matrix{Float64}:
  0.0  2.5
 
 julia> ptrace(state, [1, 3])
-GaussianState for 2 modes in CanonicalForm representation.
+GaussianState for 2 modes in QuadPairBasis representation.
 mean: 4-element Vector{Float64}:
  1.4142135623730951
  1.4142135623730951
@@ -447,21 +447,21 @@ covariance: 4×4 Matrix{Float64}:
 """
 function ptrace(::Type{Tm}, ::Type{Tc}, state::GaussianState, idx::N) where {Tm,Tc,N<:Int}
     mean′, covar′ = _ptrace(state, idx)
-    return GaussianState(typeof(state.repr)(1), Tm(mean′), Tc(covar′))
+    return GaussianState(typeof(state.basis)(1), Tm(mean′), Tc(covar′))
 end
 ptrace(::Type{T}, state::GaussianState, idx::N) where {T,N<:Int} = ptrace(T, T, state, idx)
 function ptrace(state::GaussianState, idx::N) where {N<:Int}
     mean′, covar′ = _ptrace(state, idx)
-    return GaussianState(typeof(state.repr)(1), mean′, covar′)
+    return GaussianState(typeof(state.basis)(1), mean′, covar′)
 end
 function ptrace(::Type{Tm}, ::Type{Tc}, state::GaussianState, indices::N) where {Tm,Tc,N<:AbstractVector}
     mean, covar = _ptrace(state, indices)
-    return GaussianState(typeof(state.repr)(length(indices)), Tm(mean), Tc(covar))
+    return GaussianState(typeof(state.basis)(length(indices)), Tm(mean), Tc(covar))
 end
 ptrace(::Type{T}, state::GaussianState, indices::N) where {T,N<:AbstractVector} = ptrace(T, T, state, indices)
 function ptrace(state::GaussianState, indices::T) where {T<:AbstractVector}
     mean, covar = _ptrace(state, indices)
-    return GaussianState(typeof(state.repr)(length(indices)), mean, covar)
+    return GaussianState(typeof(state.basis)(length(indices)), mean, covar)
 end
 function _ptrace(state::GaussianState, idx::T) where {T<:Int}
     idxV = 2*idx-1:(2*idx)

--- a/src/states.jl
+++ b/src/states.jl
@@ -19,8 +19,8 @@ matrix ``\\mathbf{V}``, expressed respectively as follows:
 ## Example
 
 ```jldoctest
-julia> vacuumstate()
-GaussianState for 1 mode.
+julia> vacuumstate(CanonicalForm(1))
+GaussianState for 1 mode in CanonicalForm representation.
 mean: 2-element Vector{Float64}:
  0.0
  0.0
@@ -29,16 +29,20 @@ covariance: 2×2 Matrix{Float64}:
  0.0  1.0
 ```
 """
-function vacuumstate(::Type{Tm}, ::Type{Tc}) where {Tm,Tc}
-    mean = Tm(zeros(2))
-    covar = Tc(Matrix{Float64}(I, 2, 2))
-    return GaussianState(mean, covar, 1)
+function vacuumstate(::Type{Tm}, ::Type{Tc}, repr::SymplecticRepr{N}) where {Tm,Tc,N<:Int}
+    mean, covar = _vacuumstate(repr)
+    return GaussianState(repr, Tm(mean), Tc(covar))
 end
-vacuumstate(::Type{T}) where {T} = vacuumstate(T, T)
-function vacuumstate()
-    mean = zeros(2)
-    covar = Matrix{Float64}(I, 2, 2)
-    return GaussianState(mean, covar, 1)
+vacuumstate(::Type{T}, repr::SymplecticRepr{N}) where {T,N<:Int} = vacuumstate(T, T, repr)
+function vacuumstate(repr::SymplecticRepr{N}) where {N<:Int}
+    mean, covar = _vacuumstate(repr)
+    return GaussianState(repr, mean, covar)
+end
+function _vacuumstate(repr::SymplecticRepr{N}) where {N<:Int}
+    nmodes = repr.nmodes
+    mean = zeros(2*nmodes)
+    covar = Matrix{Float64}(I, 2*nmodes, 2*nmodes)
+    return mean, covar
 end
 
 """
@@ -60,8 +64,8 @@ matrix ``\\mathbf{V}``, expressed respectively as follows:
 ## Example
 
 ```jldoctest
-julia> thermalstate(4)
-GaussianState for 1 mode.
+julia> thermalstate(CanonicalForm(1), 4)
+GaussianState for 1 mode in CanonicalForm representation.
 mean: 2-element Vector{Float64}:
  0.0
  0.0
@@ -70,16 +74,31 @@ covariance: 2×2 Matrix{Float64}:
  0.0  4.5
 ```
 """
-function thermalstate(::Type{Tm}, ::Type{Tc}, photons::N) where {Tm,Tc,N<:Int}
-    mean = Tm(zeros(2))
-    covar = (photons + 1/2) * Tc(Matrix{Float64}(I, 2, 2))
-    return GaussianState(mean, covar, 1)
+function thermalstate(::Type{Tm}, ::Type{Tc}, repr::SymplecticRepr{N}, photons::P) where {Tm,Tc,N<:Int,P}
+    mean, covar = _thermalstate(repr, photons)
+    return GaussianState(repr, Tm(mean), Tc(covar))
 end
-thermalstate(::Type{T}, photons::N) where {T, N<:Int} = thermalstate(T, T, photons)
-function thermalstate(photons::N) where {N<:Int}
-    mean = zeros(2)
-    covar = (photons + 1/2) * Matrix{Float64}(I, 2, 2)
-    return GaussianState(mean, covar, 1)
+thermalstate(::Type{T}, repr::SymplecticRepr{N}, photons::P) where {T,N<:Int,P} = thermalstate(T, T, repr, photons)
+function thermalstate(repr::SymplecticRepr{N}, photons::P) where {N<:Int,P}
+    mean, covar = _thermalstate(repr, photons)
+    return GaussianState(repr, mean, covar)
+end
+function _thermalstate(repr::CanonicalForm{N}, photons::P) where {N<:Int,P<:Int}
+    nmodes = repr.nmodes
+    mean = zeros(2*nmodes)
+    covar = Matrix{Float64}((photons + 1/2) * I, 2*nmodes, 2*nmodes)
+    return mean, covar
+end
+function _thermalstate(repr::CanonicalForm{N}, photons::P) where {N<:Int,P<:Vector}
+    nmodes = repr.nmodes
+    mean = zeros(2*nmodes)
+    covar = zeros(2*nmodes, 2*nmodes)
+    @inbounds for i in Base.OneTo(nmodes)
+        val = photons[i] + 1/2
+        covar[2*i-1, 2*i-1] = val
+        covar[2*i, 2*i] = val
+    end
+    return mean, covar
 end
 
 """
@@ -102,8 +121,8 @@ matrix ``\\mathbf{V}``, expressed respectively as follows:
 ## Example
 
 ```jldoctest
-julia> coherentstate(1.0+im)
-GaussianState for 1 mode.
+julia> coherentstate(CanonicalForm(1), 1.0+im)
+GaussianState for 1 mode in CanonicalForm representation.
 mean: 2-element Vector{Float64}:
  1.4142135623730951
  1.4142135623730951
@@ -112,16 +131,26 @@ covariance: 2×2 Matrix{Float64}:
  0.0  1.0
 ```
 """
-function coherentstate(::Type{Tm}, ::Type{Tc}, alpha::N) where {Tm,Tc,N<:Number}
-    mean = sqrt(2) * Tm([real(alpha), imag(alpha)])
-    covar = Tc(Matrix{Float64}(I, 2, 2))
-    return GaussianState(mean, covar, 1)
+function coherentstate(::Type{Tm}, ::Type{Tc}, repr::SymplecticRepr{N}, alpha::A) where {Tm,Tc,N<:Int,A}
+    mean, covar = _coherentstate(repr, alpha)
+    return GaussianState(repr, Tm(mean), Tc(covar))
 end
-coherentstate(::Type{T}, alpha::N) where {T, N<:Number} = coherentstate(T, T, alpha)
-function coherentstate(alpha::N) where {N<:Number}
-    mean = sqrt(2) * [real(alpha), imag(alpha)]
-    covar = Matrix{Float64}(I, 2, 2)
-    return GaussianState(mean, covar, 1)
+coherentstate(::Type{T}, repr::SymplecticRepr{N}, alpha::A) where {T,N<:Int,A} = coherentstate(T, T, repr, alpha)
+function coherentstate(repr::SymplecticRepr{N}, alpha::A) where {N<:Int,A}
+    mean, covar = _coherentstate(repr, alpha)
+    return GaussianState(repr, mean, covar)
+end
+function _coherentstate(repr::CanonicalForm{N}, alpha::A) where {N<:Int,A<:Number}
+    nmodes = repr.nmodes
+    mean = repeat([sqrt(2)*real(alpha), sqrt(2)*imag(alpha)], nmodes)
+    covar = Matrix{Float64}(I, 2*nmodes, 2*nmodes)
+    return mean, covar
+end
+function _coherentstate(repr::CanonicalForm{N}, alpha::A) where {N<:Int,A<:Vector}
+    nmodes = repr.nmodes
+    mean = sqrt(2) * reinterpret(Float64, alpha)
+    covar = Matrix{Float64}(I, 2*nmodes, 2*nmodes)
+    return mean, covar
 end
 
 """
@@ -148,8 +177,8 @@ where ``\\mathbf{R}(\\theta)`` is the rotation matrix.
 ## Example
 
 ```jldoctest
-julia> squeezedstate(0.5, pi/4)
-GaussianState for 1 mode.
+julia> squeezedstate(CanonicalForm(1), 0.5, pi/4)
+GaussianState for 1 mode in CanonicalForm representation.
 mean: 2-element Vector{Float64}:
  0.0
  0.0
@@ -158,19 +187,42 @@ covariance: 2×2 Matrix{Float64}:
  0.415496  1.18704
 ```
 """
-function squeezedstate(::Type{Tm}, ::Type{Tc}, r::N, theta::N) where {Tm,Tc,N<:Real}
-    mean = Tm(zeros(2))
-    cr, sr = cosh(2*r), sinh(2*r)
-    v = (1/2) * [cr-sr*cos(theta) sr*sin(theta); sr*sin(theta) cr+sr*cos(theta)]
-    covar = Tc(v)
-    return GaussianState(mean, covar, 1)
+function squeezedstate(::Type{Tm}, ::Type{Tc}, repr::SymplecticRepr{N}, r::R, theta::R) where {Tm,Tc,N<:Int,R}
+    mean, covar = _squeezedstate(repr, r, theta)
+    return GaussianState(repr, Tm(mean), Tc(covar))
 end
-squeezedstate(::Type{T}, r::N, theta::N) where {T,N<:Real} = squeezedstate(T, T, r, theta)
-function squeezedstate(r::N, theta::N) where {N<:Real}
-    mean = zeros(2)
+squeezedstate(::Type{T}, repr::SymplecticRepr{N}, r::R, theta::R) where {T,N<:Int,R} = squeezedstate(T, T, repr, r, theta)
+function squeezedstate(repr::SymplecticRepr{N}, r::R, theta::R) where {N<:Int,R}
+    mean, covar = _squeezedstate(repr, r, theta)
+    return GaussianState(repr, mean, covar)
+end
+function _squeezedstate(repr::CanonicalForm{N}, r::R, theta::R) where {N<:Int,R<:Real}
+    nmodes = repr.nmodes
+    mean = zeros(2*nmodes)
+    covar = zeros(2*nmodes, 2*nmodes)
     cr, sr = cosh(2*r), sinh(2*r)
-    covar = (1/2) * [cr-sr*cos(theta) sr*sin(theta); sr*sin(theta) cr+sr*cos(theta)]
-    return GaussianState(mean, covar, 1)
+    ct, st = cos(theta), sin(theta)
+    @inbounds for i in Base.OneTo(nmodes)
+        covar[2*i-1, 2*i-1] = (1/2) * (cr - sr*ct)
+        covar[2*i-1, 2*i] = (1/2) * sr * st
+        covar[2*i, 2*i-1] = (1/2) * sr * st
+        covar[2*i, 2*i] = (1/2) * (cr + sr*ct)
+    end
+    return mean, covar
+end
+function _squeezedstate(repr::CanonicalForm{N}, r::R, theta::R) where {N<:Int,R<:Vector}
+    nmodes = repr.nmodes
+    mean = zeros(2*nmodes)
+    covar = zeros(2*nmodes, 2*nmodes)
+    @inbounds for i in Base.OneTo(nmodes)
+        cr, sr = cosh(2*r[i]), sinh(2*r[i])
+        ct, st = cos(theta[i]), sin(theta[i])
+        covar[2*i-1, 2*i-1] = (1/2) * (cr - sr*ct)
+        covar[2*i-1, 2*i] = (1/2) * sr * st
+        covar[2*i, 2*i-1] = (1/2) * sr * st
+        covar[2*i, 2*i] = (1/2) * (cr + sr*ct)
+    end
+    return mean, covar
 end
 
 """
@@ -199,8 +251,8 @@ where ``\\mathbf{R}(\\theta)`` is the rotation matrix.
 ## Example
 
 ```jldoctest
-julia> eprstate(0.5, pi/4)
-GaussianState for 2 modes.
+julia> eprstate(CanonicalForm(2), 0.5, pi/4)
+GaussianState for 2 modes in CanonicalForm representation.
 mean: 4-element Vector{Float64}:
  0.0
  0.0
@@ -213,20 +265,65 @@ covariance: 4×4 Matrix{Float64}:
  0.415496  -0.415496  0.0        0.77154
 ```
 """
-function eprstate(::Type{Tm}, ::Type{Tc}, r::N, theta::N) where {Tm,Tc,N<:Real}
-    mean = Tm(zeros(4))
-    cr, sr = (1/2)*cosh(2*r), (1/2)*sinh(2*r)
-    ct, st = cos(theta), sin(theta)
-    covar = Tc([cr 0.0 sr*ct sr*st; 0.0 cr sr*st -sr*ct; sr*ct sr*st cr 0.0; sr*st -sr*ct 0.0 cr])
-    return GaussianState(mean, covar, 2)
+function eprstate(::Type{Tm}, ::Type{Tc}, repr::SymplecticRepr{N}, r::R, theta::R) where {Tm,Tc,N<:Int,R}
+    mean, covar = _eprstate(repr, r, theta)
+    return GaussianState(repr, Tm(mean), Tc(covar))
 end
-eprstate(::Type{T}, r::N, theta::N) where {T,N<:Real} = eprstate(T, T, r, theta)
-function eprstate(r::N, theta::N) where {N<:Real}
-    mean = zeros(4)
+eprstate(::Type{T}, repr::SymplecticRepr{N}, r::R, theta::R) where {T,N<:Int,R} = eprstate(T, T, repr, r, theta)
+function eprstate(repr::SymplecticRepr{N}, r::R, theta::R) where {N<:Int,R}
+    mean, covar = _eprstate(repr, r, theta)
+    return GaussianState(repr, mean, covar)
+end
+function _eprstate(repr::CanonicalForm{N}, r::R, theta::R) where {N<:Int,R<:Real}
+    nmodes = repr.nmodes
+    mean = zeros(2*nmodes)
     cr, sr = (1/2)*cosh(2*r), (1/2)*sinh(2*r)
     ct, st = cos(theta), sin(theta)
-    covar = [cr 0.0 sr*ct sr*st; 0.0 cr sr*st -sr*ct; sr*ct sr*st cr 0.0; sr*st -sr*ct 0.0 cr]
-    return GaussianState(mean, covar, 2)
+    covar = zeros(2*nmodes, 2*nmodes)
+    @inbounds for i in Base.OneTo(Int(nmodes/2))
+        covar[4*i-3, 4*i-3] = cr
+        covar[4*i-3, 4*i-1] = sr * ct
+        covar[4*i-3, 4*i] = sr * st
+
+        covar[4*i-2, 4*i-2] = cr
+        covar[4*i-2, 4*i-1] = sr * st
+        covar[4*i-2, 4*i] = -sr * ct
+
+        covar[4*i-1, 4*i-3] = sr * ct
+        covar[4*i-1, 4*i-2] = sr * st
+        covar[4*i-1, 4*i-1] = cr
+
+        covar[4*i, 4*i-3] = sr * st
+        covar[4*i, 4*i-2] = -sr * ct
+        covar[4*i, 4*i] = cr
+    end
+    return mean, covar
+end
+function _eprstate(repr::CanonicalForm{N}, r::R, theta::R) where {N<:Int,R<:Vector}
+    nmodes = repr.nmodes
+    mean = zeros(2*nmodes)
+    covar = zeros(2*nmodes, 2*nmodes)
+    @inbounds for i in Base.OneTo(Int(nmodes/2))
+        cr, sr = (1/2)*cosh(2*r[i]), (1/2)*sinh(2*r[i])
+        ct, st = cos(theta[i]), sin(theta[i])
+
+        covar[4*i-3, 4*i-3] = cr
+        covar[4*i-3, 4*i-1] = sr * ct
+        covar[4*i-3, 4*i] = sr * st
+
+        covar[4*i-2, 4*i-2] = cr
+        covar[4*i-2, 4*i-1] = sr * st
+        covar[4*i-2, 4*i] = -sr * ct
+
+        covar[4*i-1, 4*i-3] = sr * ct
+        covar[4*i-1, 4*i-2] = sr * st
+        covar[4*i-1, 4*i-1] = cr
+
+        covar[4*i, 4*i-3] = sr * st
+        covar[4*i, 4*i-2] = -sr * ct
+        covar[4*i, 4*i] = cr
+    end
+    return mean, covar
 end
 
 ##
@@ -240,8 +337,10 @@ tensor product of Gaussian states, which can also be called with `⊗`.
 
 ## Example
 ```jldoctest
-julia> coherentstate(1.0+im) ⊗ thermalstate(2)
-GaussianState for 2 modes.
+julia> repr = CanonicalForm(1);
+
+julia> coherentstate(repr, 1.0+im) ⊗ thermalstate(repr, 2)
+GaussianState for 2 modes in CanonicalForm representation.
 mean: 4-element Vector{Float64}:
  1.4142135623730951
  1.4142135623730951
@@ -255,17 +354,20 @@ covariance: 4×4 Matrix{Float64}:
 ```
 """
 function tensor(::Type{Tm}, ::Type{Tc}, state1::GaussianState, state2::GaussianState) where {Tm,Tc}
-    mean′, covar′ = _tensor_fields(state1, state2)
-    return GaussianState(Tm(mean′), Tc(covar′), state1.nmodes + state2.nmodes)
+    typeof(state1.repr) == typeof(state2.repr) || throw(ArgumentError(SYMPLECTIC_ERROR))
+    mean, covar = _tensor(state1, state2)
+    return GaussianState(state1.repr + state2.repr, Tm(mean), Tc(covar))
 end
 tensor(::Type{T}, state1::GaussianState, state2::GaussianState) where {T} = tensor(T, T, state1, state2)
 function tensor(state1::GaussianState, state2::GaussianState)
-    mean′, covar′ = _tensor_fields(state1, state2)
-    return GaussianState(mean′, covar′, state1.nmodes + state2.nmodes)
+    typeof(state1.repr) == typeof(state2.repr) || throw(ArgumentError(SYMPLECTIC_ERROR))
+    mean, covar = _tensor(state1, state2)
+    return GaussianState(state1.repr + state2.repr, mean, covar)
 end
-function _tensor_fields(state1::GaussianState, state2::GaussianState)
+function _tensor(state1::GaussianState, state2::GaussianState)
     mean1, mean2 = state1.mean, state2.mean
-    length1, length2 = 2*state1.nmodes, 2*state2.nmodes
+    repr1, repr2 = state1.repr, state2.repr
+    length1, length2 = 2*repr1.nmodes, 2*repr2.nmodes
     slengths = length1 + length2
     covar1, covar2 = state1.covar, state2.covar
     # initialize direct sum of mean vectors
@@ -301,8 +403,10 @@ indicated by `indices`.
 
 ## Example
 ```jldoctest
-julia> state = coherentstate(1.0+im) ⊗ thermalstate(2) ⊗ squeezedstate(3.0, pi/4)
-GaussianState for 3 modes.
+julia> repr = CanonicalForm(1);
+
+julia> state = coherentstate(repr, 1.0+im) ⊗ thermalstate(repr, 2) ⊗ squeezedstate(repr, 3.0, pi/4)
+GaussianState for 3 modes in CanonicalForm representation.
 mean: 6-element Vector{Float64}:
  1.4142135623730951
  1.4142135623730951
@@ -319,7 +423,7 @@ covariance: 6×6 Matrix{Float64}:
  0.0  0.0  0.0  0.0  71.3164  172.174
 
 julia> ptrace(state, 2)
-GaussianState for 1 mode.
+GaussianState for 1 mode in CanonicalForm representation.
 mean: 2-element Vector{Float64}:
  0.0
  0.0
@@ -328,7 +432,7 @@ covariance: 2×2 Matrix{Float64}:
  0.0  2.5
 
 julia> ptrace(state, [1, 3])
-GaussianState for 2 modes.
+GaussianState for 2 modes in CanonicalForm representation.
 mean: 4-element Vector{Float64}:
  1.4142135623730951
  1.4142135623730951
@@ -342,24 +446,24 @@ covariance: 4×4 Matrix{Float64}:
 ```
 """
 function ptrace(::Type{Tm}, ::Type{Tc}, state::GaussianState, idx::N) where {Tm,Tc,N<:Int}
-    mean′, covar′ = _ptrace_fields(state, idx)
-    return GaussianState(Tm(mean′), Tc(covar′), 1)
+    mean′, covar′ = _ptrace(state, idx)
+    return GaussianState(typeof(state.repr)(1), Tm(mean′), Tc(covar′))
 end
 ptrace(::Type{T}, state::GaussianState, idx::N) where {T,N<:Int} = ptrace(T, T, state, idx)
 function ptrace(state::GaussianState, idx::N) where {N<:Int}
-    mean′, covar′ = _ptrace_fields(state, idx)
-    return GaussianState(mean′, covar′, 1)
+    mean′, covar′ = _ptrace(state, idx)
+    return GaussianState(typeof(state.repr)(1), mean′, covar′)
 end
 function ptrace(::Type{Tm}, ::Type{Tc}, state::GaussianState, indices::N) where {Tm,Tc,N<:AbstractVector}
-    mean′, covar′ = _ptrace_fields(state, indices)
-    return GaussianState(Tm(mean′), Tc(covar′), length(indices))
+    mean, covar = _ptrace(state, indices)
+    return GaussianState(typeof(state.repr)(length(indices)), Tm(mean), Tc(covar))
 end
 ptrace(::Type{T}, state::GaussianState, indices::N) where {T,N<:AbstractVector} = ptrace(T, T, state, indices)
 function ptrace(state::GaussianState, indices::T) where {T<:AbstractVector}
-    mean′, covar′ = _ptrace_fields(state, indices)
-    return GaussianState(mean′, covar′, length(indices))
+    mean, covar = _ptrace(state, indices)
+    return GaussianState(typeof(state.repr)(length(indices)), mean, covar)
 end
-function _ptrace_fields(state::GaussianState, idx::T) where {T<:Int}
+function _ptrace(state::GaussianState, idx::T) where {T<:Int}
     idxV = 2*idx-1:(2*idx)
     mean = state.mean
     covar = state.covar
@@ -372,7 +476,7 @@ function _ptrace_fields(state::GaussianState, idx::T) where {T<:Int}
     covar′′ = _promote_output_matrix(typeof(covar), covar′, 2)
     return mean′′, covar′′
 end
-function _ptrace_fields(state::GaussianState, indices::T) where {T<:AbstractVector}
+function _ptrace(state::GaussianState, indices::T) where {T<:AbstractVector}
     idxlength = length(indices)
     mean = state.mean
     covar = state.covar

--- a/src/states.jl
+++ b/src/states.jl
@@ -473,12 +473,13 @@ function _tensor(state1::GaussianState{B1,M1,V1}, state2::GaussianState{B2,M2,V2
         mean′[i+2*nmodes1] = mean2[i]
     end
     # initialize direct sum of covariance matrices
+    covar1, covar2 = state1.covar, state2.covar
     covar′ = zeros(2*nmodes, 2*nmodes)
     @inbounds for i in block1, j in block1
         covar′[i,j] = covar1[i,j]
     end
     @inbounds for i in block2, j in block2
-        covar′[i+2*nmodes,j+2*nmodes] = covar2[i,j]
+        covar′[i+2*nmodes1,j+2*nmodes1] = covar2[i,j]
     end
     # extract output array types
     mean′′ = _promote_output_vector(typeof(mean1), typeof(mean2), mean′)
@@ -503,8 +504,6 @@ function _tensor(state1::GaussianState{B1,M1,V1}, state2::GaussianState{B2,M2,V2
         mean′[i+nmodes+nmodes1] = mean2[i+nmodes2]
     end
     # initialize direct sum of covariance matrices
-    covar1, covar2 = state1.covar, state2.covar
-    covar′ = zeros(2*nmodes, 2*nmodes)
     covar1, covar2 = state1.covar, state2.covar
     covar′ = zeros(2*nmodes, 2*nmodes)
     @inbounds for i in block1, j in block1

--- a/src/states.jl
+++ b/src/states.jl
@@ -3,9 +3,9 @@
 ##
 
 """
-    vacuumstate([Tm=Vector{Float64}, Tc=Matrix{Float64}])
+    vacuumstate([Tm=Vector{Float64}, Tc=Matrix{Float64}], basis::SymplecticBasis)
 
-Gaussian state with zero photons, known as the vacuum state.
+Gaussian state with zero photons, known as the vacuum state. The symplectic representation is defined by `basis`.
 
 ## Mathematical description of a vacuum state
 
@@ -46,10 +46,10 @@ function _vacuumstate(basis::SymplecticBasis{N}) where {N<:Int}
 end
 
 """
-    thermalstate([Tm=Vector{Float64}, Tc=Matrix{Float64},] photons<:Int)
+    thermalstate([Tm=Vector{Float64}, Tc=Matrix{Float64},] basis::SymplecticBasis, photons<:Int)
 
-Gaussian state at thermal equilibrium, known as the thermal state. The mean photon number of the
-state is given by `photons`.
+Gaussian state at thermal equilibrium, known as the thermal state. The symplectic representation
+is defined by `basis`. The mean photon number of the state is given by `photons`.
 
 ## Mathematical description of a thermal state
 
@@ -102,10 +102,11 @@ function _thermalstate(basis::QuadPairBasis{N}, photons::P) where {N<:Int,P<:Vec
 end
 
 """
-    coherentstate([Tm=Vector{Float64}, Tc=Matrix{Float64},] alpha<:Number)
+    coherentstate([Tm=Vector{Float64}, Tc=Matrix{Float64},] basis::SymplecticBasis, alpha<:Number)
 
 Gaussian state that is the quantum analogue of a monochromatic electromagnetic field, known
-as the coherent state. The complex amplitude of the state is given by `alpha`.
+as the coherent state. The symplectic representation is defined by `basis`.
+The complex amplitude of the state is given by `alpha`.
 
 ## Mathematical description of a coherent state
 
@@ -154,10 +155,10 @@ function _coherentstate(basis::QuadPairBasis{N}, alpha::A) where {N<:Int,A<:Vect
 end
 
 """
-    squeezedstate([Tm=Vector{Float64}, Tc=Matrix{Float64},] r<:Real, theta<:Real)
+    squeezedstate([Tm=Vector{Float64}, Tc=Matrix{Float64},] basis::SymplecticBasis, r<:Real, theta<:Real)
 
 Gaussian state with quantum uncertainty in its phase and amplitude, known as
-the squeezed state. The amplitude and phase squeezing parameters are given by `r`
+the squeezed state. The symplectic representation is defined by `basis`. The amplitude and phase squeezing parameters are given by `r`
 and `theta`, respectively.
 
 ## Mathematical description of a squeezed state
@@ -226,10 +227,10 @@ function _squeezedstate(basis::QuadPairBasis{N}, r::R, theta::R) where {N<:Int,R
 end
 
 """
-    eprstate([Tm=Vector{Float64}, Tc=Matrix{Float64},] r<:Real, theta<:Real)
+    eprstate([Tm=Vector{Float64}, Tc=Matrix{Float64},] basis::SymplecticBasis, r<:Real, theta<:Real)
 
-Gaussian state that is a two-mode squeezed state, known as the Einstein-Podolski-Rosen (EPR) state.
-The amplitude and phase squeezing parameters are given by `r` and `theta`, respectively.
+Gaussian state that is a two-mode squeezed state, known as the Einstein-Podolski-Rosen (EPR) state. The symplectic
+representation is defined by `basis`. The amplitude and phase squeezing parameters are given by `r` and `theta`, respectively.
 
 ## Mathematical description of an EPR state
 

--- a/src/states.jl
+++ b/src/states.jl
@@ -89,7 +89,7 @@ function _thermalstate(basis::Union{QuadPairBasis{N},QuadBlockBasis{N}}, photons
     covar = Matrix{Float64}((photons + 1/2) * I, 2*nmodes, 2*nmodes)
     return mean, covar
 end
-function _thermalstate(basis::Union{QuadPairBasis{N},QuadBlockBasis{N}}, photons::P) where {N<:Int,P<:Vector}
+function _thermalstate(basis::QuadPairBasis{N}, photons::P) where {N<:Int,P<:Vector}
     nmodes = basis.nmodes
     mean = zeros(2*nmodes)
     covar = zeros(2*nmodes, 2*nmodes)
@@ -97,6 +97,17 @@ function _thermalstate(basis::Union{QuadPairBasis{N},QuadBlockBasis{N}}, photons
         val = photons[i] + 1/2
         covar[2*i-1, 2*i-1] = val
         covar[2*i, 2*i] = val
+    end
+    return mean, covar
+end
+function _thermalstate(basis::QuadBlockBasis{N}, photons::P) where {N<:Int,P<:Vector}
+    nmodes = basis.nmodes
+    mean = zeros(2*nmodes)
+    covar = zeros(2*nmodes, 2*nmodes)
+    @inbounds for i in Base.OneTo(nmodes)
+        val = photons[i] + 1/2
+        covar[i, i] = val
+        covar[i+nmodes, i+nmodes] = val
     end
     return mean, covar
 end

--- a/src/symplectic.jl
+++ b/src/symplectic.jl
@@ -19,9 +19,9 @@ function Base.:(-)(repr1::R, repr2::R) where {R<:SymplecticBasis}
 end
 
 """
-    symplecticform([T = Matrix{Float64},] nmodes<:Int)
+    symplecticform([T = Matrix{Float64},] basis::SymplecticBasis)
 
-Compute the symplectic form matrix of size 2N x 2N, where N is given by `nmodes`.
+Compute the symplectic form matrix of size 2N x 2N corresponding to `basis`.
 """
 function symplecticform(basis::QuadPairBasis{N}) where {N<:Int}
     nmodes = basis.nmodes

--- a/src/symplectic.jl
+++ b/src/symplectic.jl
@@ -32,5 +32,20 @@ function symplecticform(repr::CanonicalForm{N}) where {N<:Int}
     end
     return Omega
 end
+function symplecticform(repr::BlockForm{N}) where {N<:Int}
+    nmodes = repr.nmodes
+    Omega = zeros(2*nmodes, 2*nmodes)
+    @inbounds for i in 1:nmodes, j in nmodes:2*nmodes
+        if isequal(i, j-nmodes)
+            Omega[i,j] = 1.0
+        end
+    end
+    @inbounds for i in nmodes:2*nmodes, j in 1:nmodes
+        if isequal(i-nmodes,j)
+            Omega[i, j] = -1.0
+        end
+    end
+    return Omega
+end
 symplecticform(::Type{T}, repr::SymplecticRepr{N}) where {T, N<:Int} = T(symplecticform(repr))
 

--- a/src/symplectic.jl
+++ b/src/symplectic.jl
@@ -1,9 +1,17 @@
 abstract type SymplecticBasis{N} end
 
+"""
+Defines a symplectic basis for a bosonic system of size `nmodes` in which
+the quadrature field operators are arranged pairwise.
+"""
 struct QuadPairBasis{N} <: SymplecticBasis{N}
     nmodes::N
 end
 
+"""
+Defines a symplectic basis for a bosonic system of size `nmodes` in which
+the quadrature field operators are arranged blockwise.
+"""
 struct QuadBlockBasis{N} <: SymplecticBasis{N}
     nmodes::N
 end

--- a/src/symplectic.jl
+++ b/src/symplectic.jl
@@ -48,4 +48,3 @@ function symplecticform(basis::QuadBlockBasis{N}) where {N<:Int}
     return Omega
 end
 symplecticform(::Type{T}, basis::SymplecticBasis{N}) where {T, N<:Int} = T(symplecticform(basis))
-

--- a/src/symplectic.jl
+++ b/src/symplectic.jl
@@ -1,0 +1,36 @@
+abstract type SymplecticRepr{N} end
+
+struct CanonicalForm{N} <: SymplecticRepr{N}
+    nmodes::N
+end
+
+struct BlockForm{N} <: SymplecticRepr{N}
+    nmodes::N
+end
+
+function Base.:(*)(n::N, repr2::R) where {N<:Number,R<:SymplecticRepr}
+    R(n*repr2.nmodes)
+end
+function Base.:(+)(repr1::R, repr2::R) where {R<:SymplecticRepr}
+    R(repr1.nmodes + repr2.nmodes)
+end
+function Base.:(-)(repr1::R, repr2::R) where {R<:SymplecticRepr}
+    R(repr1.nmodes - repr2.nmodes)
+end
+
+"""
+    symplecticform([T = Matrix{Float64},] nmodes<:Int)
+
+Compute the symplectic form matrix of size 2N x 2N, where N is given by `nmodes`.
+"""
+function symplecticform(repr::CanonicalForm{N}) where {N<:Int}
+    nmodes = repr.nmodes
+    Omega = zeros(2*nmodes, 2*nmodes)
+    @inbounds for i in Base.OneTo(nmodes)
+        Omega[2*i-1, 2*i] = 1.0
+        Omega[2*i, 2*i-1] = -1.0
+    end
+    return Omega
+end
+symplecticform(::Type{T}, repr::SymplecticRepr{N}) where {T, N<:Int} = T(symplecticform(repr))
+

--- a/src/symplectic.jl
+++ b/src/symplectic.jl
@@ -1,20 +1,20 @@
-abstract type SymplecticRepr{N} end
+abstract type SymplecticBasis{N} <: Basis end
 
-struct CanonicalForm{N} <: SymplecticRepr{N}
+struct QuadPairBasis{N} <: SymplecticBasis{N}
     nmodes::N
 end
 
-struct BlockForm{N} <: SymplecticRepr{N}
+struct QuadBlockBasis{N} <: SymplecticBasis{N}
     nmodes::N
 end
 
-function Base.:(*)(n::N, repr2::R) where {N<:Number,R<:SymplecticRepr}
+function Base.:(*)(n::N, repr2::R) where {N<:Number,R<:SymplecticBasis}
     R(n*repr2.nmodes)
 end
-function Base.:(+)(repr1::R, repr2::R) where {R<:SymplecticRepr}
+function Base.:(+)(repr1::R, repr2::R) where {R<:SymplecticBasis}
     R(repr1.nmodes + repr2.nmodes)
 end
-function Base.:(-)(repr1::R, repr2::R) where {R<:SymplecticRepr}
+function Base.:(-)(repr1::R, repr2::R) where {R<:SymplecticBasis}
     R(repr1.nmodes - repr2.nmodes)
 end
 
@@ -23,8 +23,8 @@ end
 
 Compute the symplectic form matrix of size 2N x 2N, where N is given by `nmodes`.
 """
-function symplecticform(repr::CanonicalForm{N}) where {N<:Int}
-    nmodes = repr.nmodes
+function symplecticform(basis::QuadPairBasis{N}) where {N<:Int}
+    nmodes = basis.nmodes
     Omega = zeros(2*nmodes, 2*nmodes)
     @inbounds for i in Base.OneTo(nmodes)
         Omega[2*i-1, 2*i] = 1.0
@@ -32,8 +32,8 @@ function symplecticform(repr::CanonicalForm{N}) where {N<:Int}
     end
     return Omega
 end
-function symplecticform(repr::BlockForm{N}) where {N<:Int}
-    nmodes = repr.nmodes
+function symplecticform(basis::QuadBlockBasis{N}) where {N<:Int}
+    nmodes = basis.nmodes
     Omega = zeros(2*nmodes, 2*nmodes)
     @inbounds for i in 1:nmodes, j in nmodes:2*nmodes
         if isequal(i, j-nmodes)
@@ -47,5 +47,5 @@ function symplecticform(repr::BlockForm{N}) where {N<:Int}
     end
     return Omega
 end
-symplecticform(::Type{T}, repr::SymplecticRepr{N}) where {T, N<:Int} = T(symplecticform(repr))
+symplecticform(::Type{T}, basis::SymplecticBasis{N}) where {T, N<:Int} = T(symplecticform(basis))
 

--- a/src/symplectic.jl
+++ b/src/symplectic.jl
@@ -1,4 +1,4 @@
-abstract type SymplecticBasis{N} <: Basis end
+abstract type SymplecticBasis{N} end
 
 struct QuadPairBasis{N} <: SymplecticBasis{N}
     nmodes::N

--- a/src/types.jl
+++ b/src/types.jl
@@ -103,11 +103,6 @@ function Base.show(io::IO, mime::MIME"text/plain", x::GaussianUnitary)
     print(io, "\nsymplectic: ")
     Base.show(io, mime, x.symplectic)
 end
-function issymplectic(op::GaussianUnitary)
-    symp = op.symplectic
-    omega = symplecticform(op.basis)
-    return isapprox(transpose(symp) * omega * symp, omega)
-end
 
 function Base.:(*)(op::GaussianUnitary, state::GaussianState)
     op.basis == state.basis || throw(DimensionMismatch(ACTION_ERROR))

--- a/src/types.jl
+++ b/src/types.jl
@@ -3,7 +3,7 @@ Defines a Gaussian state for an N-mode bosonic system over a 2N-dimensional phas
 
 ## Fields
 
-- `repr`: Symplectic representation for Gaussian state.
+- `basis`: Symplectic basis for Gaussian state.
 - `mean`: The mean vector of length 2N.
 - `covar`: The covariance matrix of size 2N x 2N.
 
@@ -17,8 +17,8 @@ the Wigner representation of a Gaussian state is a Gaussian function.
 ## Example
 
 ```jldoctest
-julia> coherentstate(CanonicalForm(1), 1.0+im)
-GaussianState for 1 mode in CanonicalForm representation.
+julia> coherentstate(QuadPairBasis(1), 1.0+im)
+GaussianState for 1 mode in QuadPairBasis representation.
 mean: 2-element Vector{Float64}:
  1.4142135623730951
  1.4142135623730951
@@ -27,18 +27,18 @@ covariance: 2×2 Matrix{Float64}:
  0.0  1.0
 ```
 """
-struct GaussianState{R<:SymplecticRepr,M,V} <: StateVector{M,V}
-    repr::R
+struct GaussianState{B<:SymplecticBasis,M,V} <: StateVector{M,V}
+    basis::B
     mean::M
     covar::V
-    function GaussianState(r::R, m::M, v::V) where {R,M,V}
-        all(size(v) .== length(m) .== 2*(r.nmodes)) || throw(DimensionMismatch(STATE_ERROR))
-        return new{R,M,V}(r, m, v)
+    function GaussianState(b::B, m::M, v::V) where {B,M,V}
+        all(size(v) .== length(m) .== 2*(b.nmodes)) || throw(DimensionMismatch(STATE_ERROR))
+        return new{B,M,V}(b, m, v)
     end
 end
 
-Base.:(==)(x::GaussianState, y::GaussianState) = x.repr == y.repr && x.mean == y.mean && x.covar == y.covar
-Base.isapprox(x::GaussianState, y::GaussianState) = x.repr == y.repr && isapprox(x.mean,y.mean) && isapprox(x.covar,y.covar)
+Base.:(==)(x::GaussianState, y::GaussianState) = x.basis == y.basis && x.mean == y.mean && x.covar == y.covar
+Base.isapprox(x::GaussianState, y::GaussianState) = x.basis == y.basis && isapprox(x.mean,y.mean) && isapprox(x.covar,y.covar)
 function Base.show(io::IO, mime::MIME"text/plain", x::GaussianState)
     Base.summary(io, x)
     print(io, "\nmean: ")
@@ -53,7 +53,7 @@ Defines a Gaussian unitary for an N-mode bosonic system over a 2N-dimensional ph
 
 ## Fields
 
-- `repr`: Symplectic representation for Gaussian unitary.
+- `basis`: Symplectic basis for Gaussian unitary.
 - `disp`: The displacement vector of length 2N.
 - `symplectic`: The symplectic matrix of size 2N x 2N.
 
@@ -74,8 +74,8 @@ the statistical moments of the Gaussian state:
 ## Example
 
 ```jldoctest
-julia> displace(CanonicalForm(1), 1.0+im)
-GaussianUnitary for 1 mode in CanonicalForm representation.
+julia> displace(QuadPairBasis(1), 1.0+im)
+GaussianUnitary for 1 mode in QuadPairBasis representation.
 displacement: 2-element Vector{Float64}:
  1.4142135623730951
  1.4142135623730951
@@ -84,18 +84,18 @@ symplectic: 2×2 Matrix{Float64}:
  0.0  1.0
 ```
 """
-struct GaussianUnitary{R<:SymplecticRepr,D,S} <: AbstractOperator{D,S}
-    repr::R
+struct GaussianUnitary{B<:SymplecticBasis,D,S} <: AbstractOperator{D,S}
+    basis::B
     disp::D
     symplectic::S
-    function GaussianUnitary(r::R, d::D, s::S) where {R,D,S}
-        all(size(s) .== length(d) .== 2*(r.nmodes)) || throw(DimensionMismatch(UNITARY_ERROR))
-        return new{R,D,S}(r, d, s)
+    function GaussianUnitary(b::B, d::D, s::S) where {B,D,S}
+        all(size(s) .== length(d) .== 2*(b.nmodes)) || throw(DimensionMismatch(UNITARY_ERROR))
+        return new{B,D,S}(b, d, s)
     end
 end
 
-Base.:(==)(x::GaussianUnitary, y::GaussianUnitary) = x.repr == y.repr && x.disp == y.disp && x.symplectic == y.symplectic
-Base.isapprox(x::GaussianUnitary, y::GaussianUnitary) = x.repr == y.repr && isapprox(x.disp, y.disp) && isapprox(x.symplectic, y.symplectic)
+Base.:(==)(x::GaussianUnitary, y::GaussianUnitary) = x.basis == y.basis && x.disp == y.disp && x.symplectic == y.symplectic
+Base.isapprox(x::GaussianUnitary, y::GaussianUnitary) = x.basis == y.basis && isapprox(x.disp, y.disp) && isapprox(x.symplectic, y.symplectic)
 function Base.show(io::IO, mime::MIME"text/plain", x::GaussianUnitary)
     Base.summary(io, x)
     print(io, "\ndisplacement: ")
@@ -105,14 +105,14 @@ function Base.show(io::IO, mime::MIME"text/plain", x::GaussianUnitary)
 end
 
 function Base.:(*)(op::GaussianUnitary, state::GaussianState)
-    op.repr == state.repr || throw(DimensionMismatch(ACTION_ERROR))
+    op.basis == state.basis || throw(DimensionMismatch(ACTION_ERROR))
     d, S, = op.disp, op.symplectic
     mean′ = S * state.mean .+ d
     covar′ = S * state.covar * transpose(S)
-    return GaussianState(state.repr, mean′, covar′)
+    return GaussianState(state.basis, mean′, covar′)
 end
 function apply!(state::GaussianState, op::GaussianUnitary)
-    op.repr == state.repr || throw(DimensionMismatch(ACTION_ERROR))
+    op.basis == state.basis || throw(DimensionMismatch(ACTION_ERROR))
     d, S = op.disp, op.symplectic
     state.mean .= S * state.mean .+ d
     state.covar .= S * state.covar * transpose(S)
@@ -124,7 +124,7 @@ Defines a Gaussian channel for an N-mode bosonic system over a 2N-dimensional ph
 
 ## Fields
 
-- `repr`: Symplectic representation for Gaussian channel.
+- `basis`: Symplectic representation for Gaussian channel.
 - `disp`: The displacement vector of length 2N.
 - `transform`: The transformation matrix of size 2N x 2N.
 - `noise`: The noise matrix of size 2N x 2N.
@@ -148,8 +148,8 @@ described by its maps on the statistical moments of the Gaussian state:
 ```jldoctest
 julia> noise = [1.0 -3.0; 4.0 2.0];
 
-julia> displace(CanonicalForm(1), 1.0+im, noise)
-GaussianChannel for 1 mode in CanonicalForm representation.
+julia> displace(QuadPairBasis(1), 1.0+im, noise)
+GaussianChannel for 1 mode in QuadPairBasis representation.
 displacement: 2-element Vector{Float64}:
  1.4142135623730951
  1.4142135623730951
@@ -161,19 +161,19 @@ noise: 2×2 Matrix{Float64}:
  4.0   2.0
 ```
 """
-struct GaussianChannel{R<:SymplecticRepr,D,T} <: AbstractOperator{D,T}
-    repr::R
+struct GaussianChannel{B<:SymplecticBasis,D,T} <: AbstractOperator{D,T}
+    basis::B
     disp::D
     transform::T
     noise::T
-    function GaussianChannel(r::R, d::D, t::T, n::T) where {R,D,T}
-        all(length(d) .== size(t) .== size(n) .== 2*(r.nmodes)) || throw(DimensionMismatch(CHANNEL_ERROR))
-        return new{R,D,T}(r, d, t, n)
+    function GaussianChannel(b::B, d::D, t::T, n::T) where {B,D,T}
+        all(length(d) .== size(t) .== size(n) .== 2*(b.nmodes)) || throw(DimensionMismatch(CHANNEL_ERROR))
+        return new{B,D,T}(b, d, t, n)
     end
 end
 
-Base.:(==)(x::GaussianChannel, y::GaussianChannel) = x.repr == y.repr && x.disp == y.disp && x.transform == y.transform && x.noise == y.noise
-Base.isapprox(x::GaussianChannel, y::GaussianChannel) = x.repr == y.repr && isapprox(x.disp, y.disp) && isapprox(x.transform, y.transform) && isapprox(x.noise, y.noise)
+Base.:(==)(x::GaussianChannel, y::GaussianChannel) = x.basis == y.basis && x.disp == y.disp && x.transform == y.transform && x.noise == y.noise
+Base.isapprox(x::GaussianChannel, y::GaussianChannel) = x.basis == y.basis && isapprox(x.disp, y.disp) && isapprox(x.transform, y.transform) && isapprox(x.noise, y.noise)
 function Base.show(io::IO, mime::MIME"text/plain", x::GaussianChannel)
     Base.summary(io, x)
     print(io, "\ndisplacement: ")
@@ -185,27 +185,27 @@ function Base.show(io::IO, mime::MIME"text/plain", x::GaussianChannel)
 end
 function Base.summary(io::IO, x::Union{GaussianState,GaussianUnitary,GaussianChannel})
     printstyled(io, nameof(typeof(x)); color=:blue)
-    repr = x.repr
-    modenum = repr.nmodes
+    basis = x.basis
+    modenum = basis.nmodes
     if isone(modenum)
         print(io, " for $(modenum) mode ")
     else
         print(io, " for $(modenum) modes ")
     end
     print(io, "in ")
-    printstyled(io, "$(nameof(typeof(repr)))"; color = :blue)
+    printstyled(io, "$(nameof(typeof(basis)))"; color = :blue)
     print(io, " representation.")
 end
 
 function Base.:(*)(op::GaussianChannel, state::GaussianState)
-    op.repr == state.repr || throw(DimensionMismatch(ACTION_ERROR))
+    op.basis == state.basis || throw(DimensionMismatch(ACTION_ERROR))
     d, T, N = op.disp, op.transform, op.noise
     mean′ = T * state.mean .+ d
     covar′ = T * state.covar * transpose(T) .+ N
-    return GaussianState(state.repr, mean′, covar′)
+    return GaussianState(state.basis, mean′, covar′)
 end
 function apply!(state::GaussianState, op::GaussianChannel)
-    op.repr == state.repr || throw(DimensionMismatch(ACTION_ERROR))
+    op.basis == state.basis || throw(DimensionMismatch(ACTION_ERROR))
     d, T, N = op.disp, op.transform, op.noise
     state.mean .= T * state.mean .+ d
     state.covar .= T * state.covar * transpose(T) .+ N

--- a/src/types.jl
+++ b/src/types.jl
@@ -103,6 +103,11 @@ function Base.show(io::IO, mime::MIME"text/plain", x::GaussianUnitary)
     print(io, "\nsymplectic: ")
     Base.show(io, mime, x.symplectic)
 end
+function issymplectic(op::GaussianUnitary)
+    symp = op.symplectic
+    omega = symplecticform(op.basis)
+    return isapprox(transpose(symp) * omega * symp, omega)
+end
 
 function Base.:(*)(op::GaussianUnitary, state::GaussianState)
     op.basis == state.basis || throw(DimensionMismatch(ACTION_ERROR))

--- a/src/types.jl
+++ b/src/types.jl
@@ -3,9 +3,9 @@ Defines a Gaussian state for an N-mode bosonic system over a 2N-dimensional phas
 
 ## Fields
 
+- `repr`: Symplectic representation for Gaussian state.
 - `mean`: The mean vector of length 2N.
 - `covar`: The covariance matrix of size 2N x 2N.
-- `nmodes`: The number of modes N of the Gaussian state.
 
 ## Mathematical description of a Gaussian state
 
@@ -17,8 +17,8 @@ the Wigner representation of a Gaussian state is a Gaussian function.
 ## Example
 
 ```jldoctest
-julia> coherentstate(1.0+im)
-GaussianState for 1 mode.
+julia> coherentstate(CanonicalForm(1), 1.0+im)
+GaussianState for 1 mode in CanonicalForm representation.
 mean: 2-element Vector{Float64}:
  1.4142135623730951
  1.4142135623730951
@@ -27,19 +27,18 @@ covariance: 2×2 Matrix{Float64}:
  0.0  1.0
 ```
 """
-struct GaussianState{M,V,N<:Int} <: StateVector{M,V}
+struct GaussianState{R<:SymplecticRepr,M,V} <: StateVector{M,V}
+    repr::R
     mean::M
     covar::V
-    nmodes::N
-    function GaussianState(m::M, v::V, n::N) where {M,V,N}
-        all(size(v) .== length(m) .== 2*n) || throw(DimensionMismatch(STATE_ERROR))
-        return new{M,V,N}(m, v, n)
+    function GaussianState(r::R, m::M, v::V) where {R,M,V}
+        all(size(v) .== length(m) .== 2*(r.nmodes)) || throw(DimensionMismatch(STATE_ERROR))
+        return new{R,M,V}(r, m, v)
     end
 end
-GaussianState(mean::M, covar::V) where {M,V} = GaussianState(mean, covar, Int(length(mean)/2))
 
-Base.:(==)(x::GaussianState, y::GaussianState) = x.mean == y.mean && x.covar == y.covar
-Base.isapprox(x::GaussianState, y::GaussianState) = isapprox(x.mean,y.mean) && isapprox(x.covar,y.covar)
+Base.:(==)(x::GaussianState, y::GaussianState) = x.repr == y.repr && x.mean == y.mean && x.covar == y.covar
+Base.isapprox(x::GaussianState, y::GaussianState) = x.repr == y.repr && isapprox(x.mean,y.mean) && isapprox(x.covar,y.covar)
 function Base.show(io::IO, mime::MIME"text/plain", x::GaussianState)
     Base.summary(io, x)
     print(io, "\nmean: ")
@@ -54,9 +53,9 @@ Defines a Gaussian unitary for an N-mode bosonic system over a 2N-dimensional ph
 
 ## Fields
 
+- `repr`: Symplectic representation for Gaussian unitary.
 - `disp`: The displacement vector of length 2N.
 - `symplectic`: The symplectic matrix of size 2N x 2N.
-- `nmodes`: The number of modes N for the Gaussian unitary.
 
 ## Mathematical description of a Gaussian unitary
 
@@ -75,8 +74,8 @@ the statistical moments of the Gaussian state:
 ## Example
 
 ```jldoctest
-julia> displace(1.0+im)
-GaussianUnitary for 1 mode.
+julia> displace(CanonicalForm(1), 1.0+im)
+GaussianUnitary for 1 mode in CanonicalForm representation.
 displacement: 2-element Vector{Float64}:
  1.4142135623730951
  1.4142135623730951
@@ -85,19 +84,18 @@ symplectic: 2×2 Matrix{Float64}:
  0.0  1.0
 ```
 """
-struct GaussianUnitary{D,S,N<:Int} <: AbstractOperator{D,S}
+struct GaussianUnitary{R<:SymplecticRepr,D,S} <: AbstractOperator{D,S}
+    repr::R
     disp::D
     symplectic::S
-    nmodes::N
-    function GaussianUnitary(d::D, s::S, n::N) where {D,S,N}
-        all(size(s) .== length(d) .== 2*n) || throw(DimensionMismatch(UNITARY_ERROR))
-        return new{D,S,N}(d, s, n)
+    function GaussianUnitary(r::R, d::D, s::S) where {R,D,S}
+        all(size(s) .== length(d) .== 2*(r.nmodes)) || throw(DimensionMismatch(UNITARY_ERROR))
+        return new{R,D,S}(r, d, s)
     end
 end
-GaussianUnitary(disp::D, symplectic::S) where {D,S} = GaussianUnitary(disp, symplectic, Int(length(disp)/2))
 
-Base.:(==)(x::GaussianUnitary, y::GaussianUnitary) = x.disp == y.disp && x.symplectic == y.symplectic
-Base.isapprox(x::GaussianUnitary, y::GaussianUnitary) = isapprox(x.disp, y.disp) && isapprox(x.symplectic, y.symplectic)
+Base.:(==)(x::GaussianUnitary, y::GaussianUnitary) = x.repr == y.repr && x.disp == y.disp && x.symplectic == y.symplectic
+Base.isapprox(x::GaussianUnitary, y::GaussianUnitary) = x.repr == y.repr && isapprox(x.disp, y.disp) && isapprox(x.symplectic, y.symplectic)
 function Base.show(io::IO, mime::MIME"text/plain", x::GaussianUnitary)
     Base.summary(io, x)
     print(io, "\ndisplacement: ")
@@ -107,15 +105,15 @@ function Base.show(io::IO, mime::MIME"text/plain", x::GaussianUnitary)
 end
 
 function Base.:(*)(op::GaussianUnitary, state::GaussianState)
+    op.repr == state.repr || throw(DimensionMismatch(ACTION_ERROR))
     d, S, = op.disp, op.symplectic
-    op.nmodes == state.nmodes || throw(DimensionMismatch(ACTION_ERROR))
     mean′ = S * state.mean .+ d
     covar′ = S * state.covar * transpose(S)
-    return GaussianState(mean′, covar′, state.nmodes)
+    return GaussianState(state.repr, mean′, covar′)
 end
 function apply!(state::GaussianState, op::GaussianUnitary)
+    op.repr == state.repr || throw(DimensionMismatch(ACTION_ERROR))
     d, S = op.disp, op.symplectic
-    state.nmodes == op.nmodes || throw(DimensionMismatch(ACTION_ERROR))
     state.mean .= S * state.mean .+ d
     state.covar .= S * state.covar * transpose(S)
     return state
@@ -126,10 +124,10 @@ Defines a Gaussian channel for an N-mode bosonic system over a 2N-dimensional ph
 
 ## Fields
 
+- `repr`: Symplectic representation for Gaussian channel.
 - `disp`: The displacement vector of length 2N.
 - `transform`: The transformation matrix of size 2N x 2N.
 - `noise`: The noise matrix of size 2N x 2N.
-- `nmodes`: The number of modes N for the Gaussian channel.
 
 ## Mathematical description of a Gaussian channel
 
@@ -150,8 +148,8 @@ described by its maps on the statistical moments of the Gaussian state:
 ```jldoctest
 julia> noise = [1.0 -3.0; 4.0 2.0];
 
-julia> displace(1.0+im, noise)
-GaussianChannel for 1 mode.
+julia> displace(CanonicalForm(1), 1.0+im, noise)
+GaussianChannel for 1 mode in CanonicalForm representation.
 displacement: 2-element Vector{Float64}:
  1.4142135623730951
  1.4142135623730951
@@ -163,20 +161,19 @@ noise: 2×2 Matrix{Float64}:
  4.0   2.0
 ```
 """
-struct GaussianChannel{D,T,N<:Int} <: AbstractOperator{D,T}
+struct GaussianChannel{R<:SymplecticRepr,D,T} <: AbstractOperator{D,T}
+    repr::R
     disp::D
     transform::T
     noise::T
-    nmodes::N
-    function GaussianChannel(d::D, t::T, n::T, m::N) where {D,T,N}
-        all(length(d) .== size(t) .== size(n) .== 2*m) || throw(DimensionMismatch(CHANNEL_ERROR))
-        return new{D,T,N}(d, t, n, m)
+    function GaussianChannel(r::R, d::D, t::T, n::T) where {R,D,T}
+        all(length(d) .== size(t) .== size(n) .== 2*(r.nmodes)) || throw(DimensionMismatch(CHANNEL_ERROR))
+        return new{R,D,T}(r, d, t, n)
     end
 end
-GaussianChannel(disp::D, transform::T, noise::T) where {D,T} = GaussianChannel(disp, transform, noise, Int(length(disp)/2))
 
-Base.:(==)(x::GaussianChannel, y::GaussianChannel) = x.disp == y.disp && x.transform == y.transform && x.noise == y.noise
-Base.isapprox(x::GaussianChannel, y::GaussianChannel) = isapprox(x.disp, y.disp) && isapprox(x.transform, y.transform) && isapprox(x.noise, y.noise)
+Base.:(==)(x::GaussianChannel, y::GaussianChannel) = x.repr == y.repr && x.disp == y.disp && x.transform == y.transform && x.noise == y.noise
+Base.isapprox(x::GaussianChannel, y::GaussianChannel) = x.repr == y.repr && isapprox(x.disp, y.disp) && isapprox(x.transform, y.transform) && isapprox(x.noise, y.noise)
 function Base.show(io::IO, mime::MIME"text/plain", x::GaussianChannel)
     Base.summary(io, x)
     print(io, "\ndisplacement: ")
@@ -188,24 +185,28 @@ function Base.show(io::IO, mime::MIME"text/plain", x::GaussianChannel)
 end
 function Base.summary(io::IO, x::Union{GaussianState,GaussianUnitary,GaussianChannel})
     printstyled(io, nameof(typeof(x)); color=:blue)
-    modenum = x.nmodes
+    repr = x.repr
+    modenum = repr.nmodes
     if isone(modenum)
-        print(io, " for $(modenum) mode.")
+        print(io, " for $(modenum) mode ")
     else
-        print(io, " for $(modenum) modes.")
+        print(io, " for $(modenum) modes ")
     end
+    print(io, "in ")
+    printstyled(io, "$(nameof(typeof(repr)))"; color = :blue)
+    print(io, " representation.")
 end
 
 function Base.:(*)(op::GaussianChannel, state::GaussianState)
+    op.repr == state.repr || throw(DimensionMismatch(ACTION_ERROR))
     d, T, N = op.disp, op.transform, op.noise
-    op.nmodes == state.nmodes || throw(DimensionMismatch(ACTION_ERROR))
     mean′ = T * state.mean .+ d
     covar′ = T * state.covar * transpose(T) .+ N
-    return GaussianState(mean′, covar′, state.nmodes)
+    return GaussianState(state.repr, mean′, covar′)
 end
 function apply!(state::GaussianState, op::GaussianChannel)
+    op.repr == state.repr || throw(DimensionMismatch(ACTION_ERROR))
     d, T, N = op.disp, op.transform, op.noise
-    state.nmodes == op.nmodes || throw(DimensionMismatch(ACTION_ERROR))
     state.mean .= T * state.mean .+ d
     state.covar .= T * state.covar * transpose(T) .+ N
     return state

--- a/src/unitaries.jl
+++ b/src/unitaries.jl
@@ -575,7 +575,7 @@ function tensor(op1::GaussianUnitary, op2::GaussianUnitary)
     disp, symplectic = _tensor(op1, op2)
     return GaussianUnitary(op1.basis + op2.basis, disp, symplectic)
 end
-function _tensor(op1::GaussianUnitary{B1,D1,S1}, op2::GaussianChannel{B2,D2,S2}) where {B1<:QuadPairBasis,B2<:QuadPairBasis,D1,D2,S1,S2}
+function _tensor(op1::GaussianUnitary{B1,D1,S1}, op2::GaussianUnitary{B2,D2,S2}) where {B1<:QuadPairBasis,B2<:QuadPairBasis,D1,D2,S1,S2}
     basis1, basis2 = op1.basis, op2.basis
     nmodes1, nmodes2 = basis1.nmodes, basis2.nmodes
     nmodes = nmodes1 + nmodes2

--- a/src/unitaries.jl
+++ b/src/unitaries.jl
@@ -236,7 +236,7 @@ function _twosqueeze(basis::QuadPairBasis{N}, r::R, theta::R) where {N<:Int,R<:R
     cr, sr = cosh(r), sinh(r)
     ct, st = cos(theta), sin(theta)
     symplectic = zeros(2*nmodes, 2*nmodes)
-    @inbounds for i in Base.OneTo(nmodes)
+    @inbounds for i in Base.OneTo(Int(nmodes/2))
         symplectic[4*i-3, 4*i-3] = cr
         symplectic[4*i-3, 4*i-1] = -sr * ct
         symplectic[4*i-3, 4*i] = -sr * st
@@ -259,7 +259,7 @@ function _twosqueeze(basis::QuadPairBasis{N}, r::R, theta::R) where {N<:Int,R<:V
     nmodes = basis.nmodes
     disp = zeros(2*nmodes)
     symplectic = zeros(2*nmodes, 2*nmodes)
-    @inbounds for i in Base.OneTo(nmodes)
+    @inbounds for i in Base.OneTo(Int(nmodes/2))
         cr, sr = cosh(r[i]), sinh(r[i])
         ct, st = cos(theta[i]), sin(theta[i])
 
@@ -492,7 +492,7 @@ function _beamsplitter(basis::QuadPairBasis{N}, transmit::R) where {N<:Int,R<:Re
     disp = zeros(2*nmodes)
     a1, a2 = sqrt(transmit), sqrt(1 - transmit)
     symplectic = zeros(2*nmodes, 2*nmodes)
-    @inbounds for i in Base.OneTo(nmodes)
+    @inbounds for i in Base.OneTo(Int(nmodes/2))
         symplectic[4*i-3, 4*i-3] = a2
         symplectic[4*i-3, 4*i-1] = a1
 
@@ -511,7 +511,7 @@ function _beamsplitter(basis::QuadPairBasis{N}, transmit::R) where {N<:Int,R<:Ve
     nmodes = basis.nmodes
     disp = zeros(2*nmodes)
     symplectic = zeros(2*nmodes, 2*nmodes)
-    @inbounds for i in Base.OneTo(nmodes)
+    @inbounds for i in Base.OneTo(Int(nmodes/2))
         a1, a2 = sqrt(transmit[i]), sqrt(1 - transmit[i])
 
         symplectic[4*i-3, 4*i-3] = a2

--- a/src/unitaries.jl
+++ b/src/unitaries.jl
@@ -26,8 +26,8 @@ matrix ``\\mathbf{S}``, expressed respectively as follows:
 ## Example
 
 ```jldoctest
-julia> displace(CanonicalForm(1), 1.0+im)
-GaussianUnitary for 1 mode in CanonicalForm representation.
+julia> displace(QuadPairBasis(1), 1.0+im)
+GaussianUnitary for 1 mode in QuadPairBasis representation.
 displacement: 2-element Vector{Float64}:
  1.4142135623730951
  1.4142135623730951
@@ -36,23 +36,23 @@ symplectic: 2×2 Matrix{Float64}:
  0.0  1.0
 ```
 """
-function displace(::Type{Td}, ::Type{Ts}, repr::SymplecticRepr{N}, alpha::A) where {Td,Ts,N<:Int,A}
-    disp, symplectic = _displace(repr, alpha)
-    return GaussianUnitary(repr, Td(disp), Ts(symplectic))
+function displace(::Type{Td}, ::Type{Ts}, basis::SymplecticBasis{N}, alpha::A) where {Td,Ts,N<:Int,A}
+    disp, symplectic = _displace(basis, alpha)
+    return GaussianUnitary(basis, Td(disp), Ts(symplectic))
 end
-displace(::Type{T}, repr::SymplecticRepr{N}, alpha::A) where {T,N<:Int,A} = displace(T, T, repr, alpha)
-function displace(repr::SymplecticRepr{N}, alpha::A) where {N<:Int,A}
-    disp, symplectic = _displace(repr, alpha)
-    return GaussianUnitary(repr, disp, symplectic)
+displace(::Type{T}, basis::SymplecticBasis{N}, alpha::A) where {T,N<:Int,A} = displace(T, T, basis, alpha)
+function displace(basis::SymplecticBasis{N}, alpha::A) where {N<:Int,A}
+    disp, symplectic = _displace(basis, alpha)
+    return GaussianUnitary(basis, disp, symplectic)
 end
-function _displace(repr::CanonicalForm{N}, alpha::A) where {N<:Int,A<:Number}
-    nmodes = repr.nmodes
+function _displace(basis::QuadPairBasis{N}, alpha::A) where {N<:Int,A<:Number}
+    nmodes = basis.nmodes
     disp = repeat([sqrt(2)*real(alpha), sqrt(2)*imag(alpha)], nmodes)
     symplectic = Matrix{Float64}(I, 2*nmodes, 2*nmodes)
     return disp, symplectic
 end
-function _displace(repr::CanonicalForm{N}, alpha::A) where {N<:Int,A<:Vector}
-    nmodes = repr.nmodes
+function _displace(basis::QuadPairBasis{N}, alpha::A) where {N<:Int,A<:Vector}
+    nmodes = basis.nmodes
     disp = sqrt(2) * reinterpret(Float64, alpha)
     symplectic = Matrix{Float64}(I, 2*nmodes, 2*nmodes)
     return disp, symplectic
@@ -86,8 +86,8 @@ where ``\\mathbf{R}(\\theta)`` is the rotation matrix.
 ## Example
 
 ```jldoctest
-julia> squeeze(CanonicalForm(1), 0.25, pi/4)
-GaussianUnitary for 1 mode in CanonicalForm representation.
+julia> squeeze(QuadPairBasis(1), 0.25, pi/4)
+GaussianUnitary for 1 mode in QuadPairBasis representation.
 displacement: 2-element Vector{Float64}:
  0.0
  0.0
@@ -96,17 +96,17 @@ symplectic: 2×2 Matrix{Float64}:
  -0.178624   1.21004
 ```
 """
-function squeeze(::Type{Td}, ::Type{Ts}, repr::SymplecticRepr{N}, r::R, theta::R) where {Td,Ts,N<:Int,R}
-    disp, symplectic = _squeeze(repr, r, theta)
-    return GaussianUnitary(repr, Td(disp), Ts(symplectic))
+function squeeze(::Type{Td}, ::Type{Ts}, basis::SymplecticBasis{N}, r::R, theta::R) where {Td,Ts,N<:Int,R}
+    disp, symplectic = _squeeze(basis, r, theta)
+    return GaussianUnitary(basis, Td(disp), Ts(symplectic))
 end
-squeeze(::Type{T}, repr::SymplecticRepr{N}, r::R, theta::R) where {T,N<:Int,R} = squeeze(T, T, repr, r, theta)
-function squeeze(repr::SymplecticRepr{N}, r::R, theta::R) where {N<:Int, R}
-    disp, symplectic = _squeeze(repr, r, theta)
-    return GaussianUnitary(repr, disp, symplectic)
+squeeze(::Type{T}, basis::SymplecticBasis{N}, r::R, theta::R) where {T,N<:Int,R} = squeeze(T, T, basis, r, theta)
+function squeeze(basis::SymplecticBasis{N}, r::R, theta::R) where {N<:Int, R}
+    disp, symplectic = _squeeze(basis, r, theta)
+    return GaussianUnitary(basis, disp, symplectic)
 end
-function _squeeze(repr::CanonicalForm{N}, r::R, theta::R) where {N<:Int,R<:Real}
-    nmodes = repr.nmodes
+function _squeeze(basis::QuadPairBasis{N}, r::R, theta::R) where {N<:Int,R<:Real}
+    nmodes = basis.nmodes
     disp = zeros(2*nmodes)
     cr, sr = cosh(r), sinh(r)
     ct, st = cos(theta), sin(theta)
@@ -119,8 +119,8 @@ function _squeeze(repr::CanonicalForm{N}, r::R, theta::R) where {N<:Int,R<:Real}
     end
     return disp, symplectic
 end
-function _squeeze(repr::CanonicalForm{N}, r::R, theta::R) where {N<:Int,R<:Vector}
-    nmodes = repr.nmodes
+function _squeeze(basis::QuadPairBasis{N}, r::R, theta::R) where {N<:Int,R<:Vector}
+    nmodes = basis.nmodes
     disp = zeros(2*nmodes)
     symplectic = zeros(2*nmodes, 2*nmodes)
     @inbounds for i in Base.OneTo(nmodes)
@@ -165,8 +165,8 @@ where ``\\mathbf{R}(\\theta)`` is the rotation matrix.
 ## Example
 
 ```jldoctest
-julia> twosqueeze(CanonicalForm(2), 0.25, pi/4)
-GaussianUnitary for 2 modes in CanonicalForm representation.
+julia> twosqueeze(QuadPairBasis(2), 0.25, pi/4)
+GaussianUnitary for 2 modes in QuadPairBasis representation.
 displacement: 4-element Vector{Float64}:
  0.0
  0.0
@@ -179,17 +179,17 @@ symplectic: 4×4 Matrix{Float64}:
  -0.178624   0.178624   0.0        1.03141
 ```
 """
-function twosqueeze(::Type{Td}, ::Type{Ts}, repr::SymplecticRepr{N}, r::R, theta::R) where {Td,Ts,N<:Int,R}
-    disp, symplectic = _twosqueeze(repr, r, theta)
-    return GaussianUnitary(repr, Td(disp), Ts(symplectic))
+function twosqueeze(::Type{Td}, ::Type{Ts}, basis::SymplecticBasis{N}, r::R, theta::R) where {Td,Ts,N<:Int,R}
+    disp, symplectic = _twosqueeze(basis, r, theta)
+    return GaussianUnitary(basis, Td(disp), Ts(symplectic))
 end
-twosqueeze(::Type{T}, repr::SymplecticRepr{N}, r::R, theta::R) where {T,N<:Int,R} = twosqueeze(T, T, repr, r, theta)
-function twosqueeze(repr::SymplecticRepr{N}, r::R, theta::R) where {N<:Int,R}
-    disp, symplectic = _twosqueeze(repr, r, theta)
-    return GaussianUnitary(repr, disp, symplectic)
+twosqueeze(::Type{T}, basis::SymplecticBasis{N}, r::R, theta::R) where {T,N<:Int,R} = twosqueeze(T, T, basis, r, theta)
+function twosqueeze(basis::SymplecticBasis{N}, r::R, theta::R) where {N<:Int,R}
+    disp, symplectic = _twosqueeze(basis, r, theta)
+    return GaussianUnitary(basis, disp, symplectic)
 end
-function _twosqueeze(repr::CanonicalForm{N}, r::R, theta::R) where {N<:Int,R<:Real}
-    nmodes = repr.nmodes
+function _twosqueeze(basis::QuadPairBasis{N}, r::R, theta::R) where {N<:Int,R<:Real}
+    nmodes = basis.nmodes
     disp = zeros(2*nmodes)
     cr, sr = cosh(r), sinh(r)
     ct, st = cos(theta), sin(theta)
@@ -213,8 +213,8 @@ function _twosqueeze(repr::CanonicalForm{N}, r::R, theta::R) where {N<:Int,R<:Re
     end
     return disp, symplectic
 end
-function _twosqueeze(repr::CanonicalForm{N}, r::R, theta::R) where {N<:Int,R<:Vector}
-    nmodes = repr.nmodes
+function _twosqueeze(basis::QuadPairBasis{N}, r::R, theta::R) where {N<:Int,R<:Vector}
+    nmodes = basis.nmodes
     disp = zeros(2*nmodes)
     symplectic = zeros(2*nmodes, 2*nmodes)
     @inbounds for i in Base.OneTo(nmodes)
@@ -269,8 +269,8 @@ matrix ``\\mathbf{S}``, expressed respectively as follows:
 ## Example
 
 ```jldoctest
-julia> phaseshift(CanonicalForm(1), 3pi/4)
-GaussianUnitary for 1 mode in CanonicalForm representation.
+julia> phaseshift(QuadPairBasis(1), 3pi/4)
+GaussianUnitary for 1 mode in QuadPairBasis representation.
 displacement: 2-element Vector{Float64}:
  0.0
  0.0
@@ -279,17 +279,17 @@ symplectic: 2×2 Matrix{Float64}:
  -0.707107  -0.707107
 ```
 """
-function phaseshift(::Type{Td}, ::Type{Ts}, repr::SymplecticRepr{N}, theta::R) where {Td,Ts,N<:Int,R}
-    disp, symplectic = _phaseshift(repr, theta)
-    return GaussianUnitary(repr, Td(disp), Ts(symplectic))
+function phaseshift(::Type{Td}, ::Type{Ts}, basis::SymplecticBasis{N}, theta::R) where {Td,Ts,N<:Int,R}
+    disp, symplectic = _phaseshift(basis, theta)
+    return GaussianUnitary(basis, Td(disp), Ts(symplectic))
 end
-phaseshift(::Type{T}, repr::SymplecticRepr{N}, theta::R) where {T,N<:Int,R} = phaseshift(T, T, repr, theta)
-function phaseshift(repr::SymplecticRepr{N}, theta::R) where {N<:Int,R}
-    disp, symplectic = _phaseshift(repr, theta)
-    return GaussianUnitary(repr, disp, symplectic)
+phaseshift(::Type{T}, basis::SymplecticBasis{N}, theta::R) where {T,N<:Int,R} = phaseshift(T, T, basis, theta)
+function phaseshift(basis::SymplecticBasis{N}, theta::R) where {N<:Int,R}
+    disp, symplectic = _phaseshift(basis, theta)
+    return GaussianUnitary(basis, disp, symplectic)
 end
-function _phaseshift(repr::CanonicalForm{N}, theta::R) where {N<:Int,R}
-    nmodes = repr.nmodes
+function _phaseshift(basis::QuadPairBasis{N}, theta::R) where {N<:Int,R}
+    nmodes = basis.nmodes
     disp = zeros(2*nmodes)
     ct, st = cos(theta), sin(theta)
     symplectic = zeros(2*nmodes, 2*nmodes)
@@ -301,8 +301,8 @@ function _phaseshift(repr::CanonicalForm{N}, theta::R) where {N<:Int,R}
     end
     return disp, symplectic
 end
-function _phaseshift(repr::CanonicalForm{N}, theta::R) where {N<:Int,R<:Vector}
-    nmodes = repr.nmodes
+function _phaseshift(basis::QuadPairBasis{N}, theta::R) where {N<:Int,R<:Vector}
+    nmodes = basis.nmodes
     disp = zeros(2*nmodes)
     symplectic = zeros(2*nmodes, 2*nmodes)
     @inbounds for i in Base.OneTo(nmodes)
@@ -345,8 +345,8 @@ matrix ``\\mathbf{S}``, expressed respectively as follows:
 ## Example
 
 ```jldoctest
-julia> beamsplitter(CanonicalForm(2), 0.75)
-GaussianUnitary for 2 modes in CanonicalForm representation.
+julia> beamsplitter(QuadPairBasis(2), 0.75)
+GaussianUnitary for 2 modes in QuadPairBasis representation.
 displacement: 4-element Vector{Float64}:
  0.0
  0.0
@@ -359,17 +359,17 @@ symplectic: 4×4 Matrix{Float64}:
   0.0       -0.5       0.0       0.866025
 ```
 """
-function beamsplitter(::Type{Td}, ::Type{Ts}, repr::SymplecticRepr{N}, transmit::R) where {Td,Ts,N<:Int,R}
-    disp, symplectic = _beamsplitter(repr, transmit)
-    return GaussianUnitary(repr, Td(disp), Ts(symplectic))
+function beamsplitter(::Type{Td}, ::Type{Ts}, basis::SymplecticBasis{N}, transmit::R) where {Td,Ts,N<:Int,R}
+    disp, symplectic = _beamsplitter(basis, transmit)
+    return GaussianUnitary(basis, Td(disp), Ts(symplectic))
 end
-beamsplitter(::Type{T}, repr::SymplecticRepr{N}, transmit::R) where {T,N<:Int,R} = beamsplitter(T, T, repr, transmit)
-function beamsplitter(repr::SymplecticRepr{N}, transmit::R) where {N<:Int,R}
-    disp, symplectic = _beamsplitter(repr, transmit)
-    return GaussianUnitary(repr, disp, symplectic)
+beamsplitter(::Type{T}, basis::SymplecticBasis{N}, transmit::R) where {T,N<:Int,R} = beamsplitter(T, T, basis, transmit)
+function beamsplitter(basis::SymplecticBasis{N}, transmit::R) where {N<:Int,R}
+    disp, symplectic = _beamsplitter(basis, transmit)
+    return GaussianUnitary(basis, disp, symplectic)
 end
-function _beamsplitter(repr::CanonicalForm{N}, transmit::R) where {N<:Int,R<:Real}
-    nmodes = repr.nmodes
+function _beamsplitter(basis::QuadPairBasis{N}, transmit::R) where {N<:Int,R<:Real}
+    nmodes = basis.nmodes
     disp = zeros(2*nmodes)
     a1, a2 = sqrt(transmit), sqrt(1 - transmit)
     symplectic = zeros(2*nmodes, 2*nmodes)
@@ -388,8 +388,8 @@ function _beamsplitter(repr::CanonicalForm{N}, transmit::R) where {N<:Int,R<:Rea
     end
     return disp, symplectic
 end
-function _beamsplitter(repr::CanonicalForm{N}, transmit::R) where {N<:Int,R<:Vector}
-    nmodes = repr.nmodes
+function _beamsplitter(basis::QuadPairBasis{N}, transmit::R) where {N<:Int,R<:Vector}
+    nmodes = basis.nmodes
     disp = zeros(2*nmodes)
     symplectic = zeros(2*nmodes, 2*nmodes)
     @inbounds for i in Base.OneTo(nmodes)
@@ -415,18 +415,18 @@ end
 ##
 
 function tensor(::Type{Td}, ::Type{Ts}, op1::GaussianUnitary, op2::GaussianUnitary) where {Td,Ts}
-    typeof(op1.repr) == typeof(op2.repr) || throw(ArgumentError(SYMPLECTIC_ERROR))
+    typeof(op1.basis) == typeof(op2.basis) || throw(ArgumentError(SYMPLECTIC_ERROR))
     disp, symplectic = _tensor(op1, op2)
-    return GaussianUnitary(op1.repr + op2.repr, Td(disp), Ts(symplectic))
+    return GaussianUnitary(op1.basis + op2.basis, Td(disp), Ts(symplectic))
 end
 tensor(::Type{T}, op1::GaussianUnitary, op2::GaussianUnitary) where {T} = tensor(T, T, op1, op2)
 function tensor(op1::GaussianUnitary, op2::GaussianUnitary)
     disp, symplectic = _tensor(op1, op2)
-    return GaussianUnitary(op1.repr + op2.repr, disp, symplectic)
+    return GaussianUnitary(op1.basis + op2.basis, disp, symplectic)
 end
 function _tensor(op1::GaussianUnitary, op2::GaussianUnitary)
     disp1, disp2 = op1.disp, op2.disp
-    repr1, repr2 = op1.repr, op2.repr
+    repr1, repr2 = op1.basis, op2.basis
     length1, length2 = 2*repr1.nmodes, 2*repr2.nmodes
     slengths = length1 + length2
     symp1, symp2 = op1.symplectic, op2.symplectic

--- a/src/unitaries.jl
+++ b/src/unitaries.jl
@@ -311,8 +311,8 @@ function _twosqueeze(basis::QuadBlockBasis{N}, r::R, theta::R) where {N<:Int,R<:
     disp = zeros(2*nmodes)
     symplectic = zeros(2*nmodes, 2*nmodes)
     @inbounds for i in Base.OneTo(Int(nmodes/2))
-        cr, sr = cosh(r[2*i]), sinh(r[2*i])
-        ct, st = cos(theta[2*i]), sin(theta[2*i])
+        cr, sr = cosh(r[i]), sinh(r[i])
+        ct, st = cos(theta[i]), sin(theta[i])
 
         symplectic[2*i-1, 2*i-1] = cr
         symplectic[2*i-1, 2*i] = -sr * ct
@@ -521,7 +521,7 @@ function _beamsplitter(basis::QuadPairBasis{N}, transmit::R) where {N<:Int,R<:Ve
         symplectic[4*i-2, 4*i] = a1
     
         symplectic[4*i-1, 4*i-3] = -a1
-        symplectic[4*i-1, 4*i-1] = a1
+        symplectic[4*i-1, 4*i-1] = a2
 
         symplectic[4*i, 4*i-2] = -a1
         symplectic[4*i, 4*i] = a2

--- a/src/unitaries.jl
+++ b/src/unitaries.jl
@@ -26,8 +26,8 @@ matrix ``\\mathbf{S}``, expressed respectively as follows:
 ## Example
 
 ```jldoctest
-julia> displace(1.0+im)
-GaussianUnitary for 1 mode.
+julia> displace(CanonicalForm(1), 1.0+im)
+GaussianUnitary for 1 mode in CanonicalForm representation.
 displacement: 2-element Vector{Float64}:
  1.4142135623730951
  1.4142135623730951
@@ -36,16 +36,26 @@ symplectic: 2×2 Matrix{Float64}:
  0.0  1.0
 ```
 """
-function displace(::Type{Td}, ::Type{Ts}, alpha::N) where {Td,Ts,N<:Number}
-    disp = Td(sqrt(2) * [real(alpha), imag(alpha)])
-    symplectic = Ts(Matrix{Float64}(I, 2, 2))
-    return GaussianUnitary(disp, symplectic, 1)
+function displace(::Type{Td}, ::Type{Ts}, repr::SymplecticRepr{N}, alpha::A) where {Td,Ts,N<:Int,A}
+    disp, symplectic = _displace(repr, alpha)
+    return GaussianUnitary(repr, Td(disp), Ts(symplectic))
 end
-displace(::Type{T}, alpha::N) where {T,N<:Number} = displace(T, T, alpha)
-function displace(alpha::N) where {N<:Number}
-    disp = sqrt(2) * [real(alpha), imag(alpha)]
-    symplectic = Matrix{Float64}(I, 2, 2)
-    return GaussianUnitary(disp, symplectic, 1)
+displace(::Type{T}, repr::SymplecticRepr{N}, alpha::A) where {T,N<:Int,A} = displace(T, T, repr, alpha)
+function displace(repr::SymplecticRepr{N}, alpha::A) where {N<:Int,A}
+    disp, symplectic = _displace(repr, alpha)
+    return GaussianUnitary(repr, disp, symplectic)
+end
+function _displace(repr::CanonicalForm{N}, alpha::A) where {N<:Int,A<:Number}
+    nmodes = repr.nmodes
+    disp = repeat([sqrt(2)*real(alpha), sqrt(2)*imag(alpha)], nmodes)
+    symplectic = Matrix{Float64}(I, 2*nmodes, 2*nmodes)
+    return disp, symplectic
+end
+function _displace(repr::CanonicalForm{N}, alpha::A) where {N<:Int,A<:Vector}
+    nmodes = repr.nmodes
+    disp = sqrt(2) * reinterpret(Float64, alpha)
+    symplectic = Matrix{Float64}(I, 2*nmodes, 2*nmodes)
+    return disp, symplectic
 end
 
 """
@@ -76,29 +86,52 @@ where ``\\mathbf{R}(\\theta)`` is the rotation matrix.
 ## Example
 
 ```jldoctest
-julia> squeeze(0.25, pi/4)
-GaussianUnitary for 1 mode.
+julia> squeeze(CanonicalForm(1), 0.25, pi/4)
+GaussianUnitary for 1 mode in CanonicalForm representation.
 displacement: 2-element Vector{Float64}:
  0.0
  0.0
 symplectic: 2×2 Matrix{Float64}:
- 0.215425   0.0451226
- 0.0451226  0.30567
+  0.852789  -0.178624
+ -0.178624   1.21004
 ```
 """
-function squeeze(::Type{Td}, ::Type{Ts}, r::N, theta::N) where {Td,Ts,N<:Real}
-    disp = Td(zeros(2))
-    cr, sr = cosh(r), sinh(r)
-    s = sinh(r) * [cr-sr*cos(theta) sr*sin(theta); sr*sin(theta) cr+sr*cos(theta)]
-    symplectic = Ts(s)
-    return GaussianUnitary(disp, symplectic, 1)
+function squeeze(::Type{Td}, ::Type{Ts}, repr::SymplecticRepr{N}, r::R, theta::R) where {Td,Ts,N<:Int,R}
+    disp, symplectic = _squeeze(repr, r, theta)
+    return GaussianUnitary(repr, Td(disp), Ts(symplectic))
 end
-squeeze(::Type{T}, r::N, theta::N) where {T,N<:Real} = squeeze(T, T, r, theta)
-function squeeze(r::N, theta::N) where {N<:Real}
-    disp = zeros(2)
+squeeze(::Type{T}, repr::SymplecticRepr{N}, r::R, theta::R) where {T,N<:Int,R} = squeeze(T, T, repr, r, theta)
+function squeeze(repr::SymplecticRepr{N}, r::R, theta::R) where {N<:Int, R}
+    disp, symplectic = _squeeze(repr, r, theta)
+    return GaussianUnitary(repr, disp, symplectic)
+end
+function _squeeze(repr::CanonicalForm{N}, r::R, theta::R) where {N<:Int,R<:Real}
+    nmodes = repr.nmodes
+    disp = zeros(2*nmodes)
     cr, sr = cosh(r), sinh(r)
-    symplectic = sinh(r) * [cr-sr*cos(theta) sr*sin(theta); sr*sin(theta) cr+sr*cos(theta)]
-    return GaussianUnitary(disp, symplectic, 1)
+    ct, st = cos(theta), sin(theta)
+    symplectic = zeros(2*nmodes, 2*nmodes)
+    @inbounds for i in Base.OneTo(nmodes)
+        symplectic[2*i-1, 2*i-1] = cr - sr*ct
+        symplectic[2*i-1, 2*i] = -sr * st
+        symplectic[2*i, 2*i-1] = -sr * st
+        symplectic[2*i, 2*i] = cr + sr*ct
+    end
+    return disp, symplectic
+end
+function _squeeze(repr::CanonicalForm{N}, r::R, theta::R) where {N<:Int,R<:Vector}
+    nmodes = repr.nmodes
+    disp = zeros(2*nmodes)
+    symplectic = zeros(2*nmodes, 2*nmodes)
+    @inbounds for i in Base.OneTo(nmodes)
+        cr, sr = cosh(r[i]), sinh(r[i])
+        ct, st = cos(theta[i]), sin(theta[i])
+        symplectic[2*i-1, 2*i-1] = cr - sr*ct
+        symplectic[2*i-1, 2*i] = -sr * st
+        symplectic[2*i, 2*i-1] = -sr * st
+        symplectic[2*i, 2*i] = cr + sr*ct
+    end
+    return disp, symplectic
 end
 
 """
@@ -132,8 +165,8 @@ where ``\\mathbf{R}(\\theta)`` is the rotation matrix.
 ## Example
 
 ```jldoctest
-julia> twosqueeze(0.25, pi/4)
-GaussianUnitary for 2 modes.
+julia> twosqueeze(CanonicalForm(2), 0.25, pi/4)
+GaussianUnitary for 2 modes in CanonicalForm representation.
 displacement: 4-element Vector{Float64}:
  0.0
  0.0
@@ -146,20 +179,65 @@ symplectic: 4×4 Matrix{Float64}:
  -0.178624   0.178624   0.0        1.03141
 ```
 """
-function twosqueeze(::Type{Td}, ::Type{Ts}, r::N, theta::N) where {Td,Ts,N<:Real}
-    disp = Td(zeros(4))
-    cr, sr = cosh(r), sinh(r)
-    ct, st = cos(theta), sin(theta)
-    symplectic = Ts([cr 0.0 -(sr*ct) -(sr*st); 0.0 cr -(sr*st) sr*ct; -(sr*ct) -(sr*st) cr 0.0; -(sr*st) sr*ct 0.0 cr])
-    return GaussianUnitary(disp, symplectic, 2)
+function twosqueeze(::Type{Td}, ::Type{Ts}, repr::SymplecticRepr{N}, r::R, theta::R) where {Td,Ts,N<:Int,R}
+    disp, symplectic = _twosqueeze(repr, r, theta)
+    return GaussianUnitary(repr, Td(disp), Ts(symplectic))
 end
-twosqueeze(::Type{T}, r::N, theta::N) where {T,N<:Real} = twosqueeze(T, T, r, theta)
-function twosqueeze(r::N, theta::N) where {N<:Real}
-    disp = zeros(4)
+twosqueeze(::Type{T}, repr::SymplecticRepr{N}, r::R, theta::R) where {T,N<:Int,R} = twosqueeze(T, T, repr, r, theta)
+function twosqueeze(repr::SymplecticRepr{N}, r::R, theta::R) where {N<:Int,R}
+    disp, symplectic = _twosqueeze(repr, r, theta)
+    return GaussianUnitary(repr, disp, symplectic)
+end
+function _twosqueeze(repr::CanonicalForm{N}, r::R, theta::R) where {N<:Int,R<:Real}
+    nmodes = repr.nmodes
+    disp = zeros(2*nmodes)
     cr, sr = cosh(r), sinh(r)
     ct, st = cos(theta), sin(theta)
-    symplectic = [cr 0.0 -(sr*ct) -(sr*st); 0.0 cr -(sr*st) sr*ct; -(sr*ct) -(sr*st) cr 0.0; -(sr*st) sr*ct 0.0 cr]
-    return GaussianUnitary(disp, symplectic, 2)
+    symplectic = zeros(2*nmodes, 2*nmodes)
+    @inbounds for i in Base.OneTo(nmodes)
+        symplectic[4*i-3, 4*i-3] = cr
+        symplectic[4*i-3, 4*i-1] = -sr * ct
+        symplectic[4*i-3, 4*i] = -sr * st
+
+        symplectic[4*i-2, 4*i-2] = cr
+        symplectic[4*i-2, 4*i-1] = -sr * st
+        symplectic[4*i-2, 4*i] = sr * ct
+
+        symplectic[4*i-1, 4*i-3] = -sr * ct
+        symplectic[4*i-1, 4*i-2] = -sr * st
+        symplectic[4*i-1, 4*i-1] = cr
+
+        symplectic[4*i, 4*i-3] = -sr * st
+        symplectic[4*i, 4*i-2] = sr * ct
+        symplectic[4*i, 4*i] = cr
+    end
+    return disp, symplectic
+end
+function _twosqueeze(repr::CanonicalForm{N}, r::R, theta::R) where {N<:Int,R<:Vector}
+    nmodes = repr.nmodes
+    disp = zeros(2*nmodes)
+    symplectic = zeros(2*nmodes, 2*nmodes)
+    @inbounds for i in Base.OneTo(nmodes)
+        cr, sr = cosh(r[i]), sinh(r[i])
+        ct, st = cos(theta[i]), sin(theta[i])
+
+        symplectic[4*i-3, 4*i-3] = cr
+        symplectic[4*i-3, 4*i-1] = -sr * ct
+        symplectic[4*i-3, 4*i] = -sr * st
+
+        symplectic[4*i-2, 4*i-2] = cr
+        symplectic[4*i-2, 4*i-1] = -sr * st
+        symplectic[4*i-2, 4*i] = sr * ct
+
+        symplectic[4*i-1, 4*i-3] = -sr * ct
+        symplectic[4*i-1, 4*i-2] = -sr * st
+        symplectic[4*i-1, 4*i-1] = cr
+
+        symplectic[4*i, 4*i-3] = -sr * st
+        symplectic[4*i, 4*i-2] = sr * ct
+        symplectic[4*i, 4*i] = cr
+    end
+    return disp, symplectic
 end
 
 """
@@ -191,8 +269,8 @@ matrix ``\\mathbf{S}``, expressed respectively as follows:
 ## Example
 
 ```jldoctest
-julia> phaseshift(3pi/4)
-GaussianUnitary for 1 mode.
+julia> phaseshift(CanonicalForm(1), 3pi/4)
+GaussianUnitary for 1 mode in CanonicalForm representation.
 displacement: 2-element Vector{Float64}:
  0.0
  0.0
@@ -201,16 +279,40 @@ symplectic: 2×2 Matrix{Float64}:
  -0.707107  -0.707107
 ```
 """
-function phaseshift(::Type{Td}, ::Type{Ts}, theta::N) where {Td,Ts,N<:Real}
-    disp = Td(zeros(2))
-    symplectic = Ts([cos(theta) sin(theta); -sin(theta) cos(theta)])
-    return GaussianUnitary(disp, symplectic, 1)
+function phaseshift(::Type{Td}, ::Type{Ts}, repr::SymplecticRepr{N}, theta::R) where {Td,Ts,N<:Int,R}
+    disp, symplectic = _phaseshift(repr, theta)
+    return GaussianUnitary(repr, Td(disp), Ts(symplectic))
 end
-phaseshift(::Type{T}, theta::N) where {T,N<:Real} = phaseshift(T, T, theta)
-function phaseshift(theta::N) where {N<:Real}
-    disp = zeros(2)
-    symplectic = [cos(theta) sin(theta); -sin(theta) cos(theta)]
-    return GaussianUnitary(disp, symplectic, 1)
+phaseshift(::Type{T}, repr::SymplecticRepr{N}, theta::R) where {T,N<:Int,R} = phaseshift(T, T, repr, theta)
+function phaseshift(repr::SymplecticRepr{N}, theta::R) where {N<:Int,R}
+    disp, symplectic = _phaseshift(repr, theta)
+    return GaussianUnitary(repr, disp, symplectic)
+end
+function _phaseshift(repr::CanonicalForm{N}, theta::R) where {N<:Int,R}
+    nmodes = repr.nmodes
+    disp = zeros(2*nmodes)
+    ct, st = cos(theta), sin(theta)
+    symplectic = zeros(2*nmodes, 2*nmodes)
+    @inbounds for i in Base.OneTo(nmodes)
+        symplectic[2*i-1, 2*i-1] = ct
+        symplectic[2*i-1, 2*i] = st
+        symplectic[2*i, 2*i-1] = -st
+        symplectic[2*i, 2*i] = ct
+    end
+    return disp, symplectic
+end
+function _phaseshift(repr::CanonicalForm{N}, theta::R) where {N<:Int,R<:Vector}
+    nmodes = repr.nmodes
+    disp = zeros(2*nmodes)
+    symplectic = zeros(2*nmodes, 2*nmodes)
+    @inbounds for i in Base.OneTo(nmodes)
+        ct, st = cos(theta[i]), sin(theta[i])
+        symplectic[2*i-1, 2*i-1] = ct
+        symplectic[2*i-1, 2*i] = st
+        symplectic[2*i, 2*i-1] = -st
+        symplectic[2*i, 2*i] = ct
+    end
+    return disp, symplectic
 end
 
 """
@@ -243,8 +345,8 @@ matrix ``\\mathbf{S}``, expressed respectively as follows:
 ## Example
 
 ```jldoctest
-julia> beamsplitter(0.75)
-GaussianUnitary for 2 modes.
+julia> beamsplitter(CanonicalForm(2), 0.75)
+GaussianUnitary for 2 modes in CanonicalForm representation.
 displacement: 4-element Vector{Float64}:
  0.0
  0.0
@@ -257,19 +359,55 @@ symplectic: 4×4 Matrix{Float64}:
   0.0       -0.5       0.0       0.866025
 ```
 """
-function beamsplitter(::Type{Td}, ::Type{Ts}, transmit::N) where {Td,Ts,N<:Real}
-    disp = Td(zeros(4))
-    a1, a2 = sqrt(transmit), sqrt(1 - transmit)
-    symplectic = Ts([a1 0.0 a2 0.0; 0.0 a1 0.0 a2; -a2 0.0 a1 0.0; 0.0 -a2 0.0 a1])
-    return GaussianUnitary(disp, symplectic, 2)
+function beamsplitter(::Type{Td}, ::Type{Ts}, repr::SymplecticRepr{N}, transmit::R) where {Td,Ts,N<:Int,R}
+    disp, symplectic = _beamsplitter(repr, transmit)
+    return GaussianUnitary(repr, Td(disp), Ts(symplectic))
 end
-beamsplitter(::Type{T}, transmit::N) where {T,N<:Real} = beamsplitter(T, T, transmit)
-function beamsplitter(transmit::N) where {N<:Real}
-    disp = zeros(4)
-    I2 = Matrix{Float64}(I, 2, 2)
+beamsplitter(::Type{T}, repr::SymplecticRepr{N}, transmit::R) where {T,N<:Int,R} = beamsplitter(T, T, repr, transmit)
+function beamsplitter(repr::SymplecticRepr{N}, transmit::R) where {N<:Int,R}
+    disp, symplectic = _beamsplitter(repr, transmit)
+    return GaussianUnitary(repr, disp, symplectic)
+end
+function _beamsplitter(repr::CanonicalForm{N}, transmit::R) where {N<:Int,R<:Real}
+    nmodes = repr.nmodes
+    disp = zeros(2*nmodes)
     a1, a2 = sqrt(transmit), sqrt(1 - transmit)
-    symplectic = [a1 0.0 a2 0.0; 0.0 a1 0.0 a2; -a2 0.0 a1 0.0; 0.0 -a2 0.0 a1]
-    return GaussianUnitary(disp, symplectic, 2)
+    symplectic = zeros(2*nmodes, 2*nmodes)
+    @inbounds for i in Base.OneTo(nmodes)
+        symplectic[4*i-3, 4*i-3] = a1
+        symplectic[4*i-3, 4*i-1] = a2
+
+        symplectic[4*i-2, 4*i-2] = a1
+        symplectic[4*i-2, 4*i] = a2
+    
+        symplectic[4*i-1, 4*i-3] = -a2
+        symplectic[4*i-1, 4*i-1] = a1
+
+        symplectic[4*i, 4*i-2] = -a2
+        symplectic[4*i, 4*i] = a1
+    end
+    return disp, symplectic
+end
+function _beamsplitter(repr::CanonicalForm{N}, transmit::R) where {N<:Int,R<:Vector}
+    nmodes = repr.nmodes
+    disp = zeros(2*nmodes)
+    symplectic = zeros(2*nmodes, 2*nmodes)
+    @inbounds for i in Base.OneTo(nmodes)
+        a1, a2 = sqrt(transmit[i]), sqrt(1 - transmit[i])
+
+        symplectic[4*i-3, 4*i-3] = a1
+        symplectic[4*i-3, 4*i-1] = a2
+
+        symplectic[4*i-2, 4*i-2] = a1
+        symplectic[4*i-2, 4*i] = a2
+    
+        symplectic[4*i-1, 4*i-3] = -a2
+        symplectic[4*i-1, 4*i-1] = a1
+
+        symplectic[4*i, 4*i-2] = -a2
+        symplectic[4*i, 4*i] = a1
+    end
+    return disp, symplectic
 end
 
 ##
@@ -277,17 +415,19 @@ end
 ##
 
 function tensor(::Type{Td}, ::Type{Ts}, op1::GaussianUnitary, op2::GaussianUnitary) where {Td,Ts}
-    disp′, symplectic′ = _tensor_fields(op1, op2)
-    return GaussianUnitary(Td(disp′), Ts(symplectic′), op1.nmodes + op2.nmodes)
+    typeof(op1.repr) == typeof(op2.repr) || throw(ArgumentError(SYMPLECTIC_ERROR))
+    disp, symplectic = _tensor(op1, op2)
+    return GaussianUnitary(op1.repr + op2.repr, Td(disp), Ts(symplectic))
 end
 tensor(::Type{T}, op1::GaussianUnitary, op2::GaussianUnitary) where {T} = tensor(T, T, op1, op2)
 function tensor(op1::GaussianUnitary, op2::GaussianUnitary)
-    disp′, symplectic′ = _tensor_fields(op1, op2)
-    return GaussianUnitary(disp′, symplectic′, op1.nmodes + op2.nmodes)
+    disp, symplectic = _tensor(op1, op2)
+    return GaussianUnitary(op1.repr + op2.repr, disp, symplectic)
 end
-function _tensor_fields(op1::GaussianUnitary, op2::GaussianUnitary)
+function _tensor(op1::GaussianUnitary, op2::GaussianUnitary)
     disp1, disp2 = op1.disp, op2.disp
-    length1, length2 = 2*op1.nmodes, 2*op2.nmodes
+    repr1, repr2 = op1.repr, op2.repr
+    length1, length2 = 2*repr1.nmodes, 2*repr2.nmodes
     slengths = length1 + length2
     symp1, symp2 = op1.symplectic, op2.symplectic
     # initialize direct sum of displacement vectors

--- a/src/unitaries.jl
+++ b/src/unitaries.jl
@@ -3,11 +3,11 @@
 ##
 
 """
-    displace([Tm=Vector{Float64}, Ts=Matrix{Float64}], alpha<:Number)
-    displace([Tm=Vector{Float64}, Ts=Matrix{Float64}], alpha<:Number, noise::Ts)
+    displace([Tm=Vector{Float64}, Ts=Matrix{Float64}], basis::SymplecticBasis, alpha<:Number)
+    displace([Tm=Vector{Float64}, Ts=Matrix{Float64}], basis::SymplecticBasis, alpha<:Number, noise::Ts)
 
 Gaussian operator that displaces the vacuum state into a coherent state, known
-as the displacement operator. The complex amplitude is given by `alpha`. Noise can
+as the displacement operator. The symplectic representation is given by `basis`. The complex amplitude is given by `alpha`. Noise can
 be added to the operation with `noise`.
 
 ## Mathematical description of a displacement operator
@@ -59,11 +59,11 @@ function _displace(basis::QuadPairBasis{N}, alpha::A) where {N<:Int,A<:Vector}
 end
 
 """
-    squeeze([Tm=Vector{Float64}, Ts=Matrix{Float64}], r<:Real, theta<:Real)
-    squeeze([Tm=Vector{Float64}, Ts=Matrix{Float64}], r<:Real, theta<:Real, noise::Ts)
+    squeeze([Tm=Vector{Float64}, Ts=Matrix{Float64}], basis::SymplecticBasis, r<:Real, theta<:Real)
+    squeeze([Tm=Vector{Float64}, Ts=Matrix{Float64}], basis::SymplecticBasis, r<:Real, theta<:Real, noise::Ts)
 
 Gaussian operator that squeezes the vacuum state into a squeezed state, known
-as the squeezing operator. The amplitude and phase squeezing parameters 
+as the squeezing operator. The symplectic representation is given by `basis`. The amplitude and phase squeezing parameters 
 are given by `r` and `theta`, respectively. Noise can be added to the operation
 with `noise`.
 
@@ -135,11 +135,11 @@ function _squeeze(basis::QuadPairBasis{N}, r::R, theta::R) where {N<:Int,R<:Vect
 end
 
 """
-    twosqueeze([Tm=Vector{Float64}, Ts=Matrix{Float64}], r<:Real, theta<:Real)
-    twosqueeze([Tm=Vector{Float64}, Ts=Matrix{Float64}], r<:Real, theta<:Real, noise::Ts)
+    twosqueeze([Tm=Vector{Float64}, Ts=Matrix{Float64}], basis::SymplecticBasis, r<:Real, theta<:Real)
+    twosqueeze([Tm=Vector{Float64}, Ts=Matrix{Float64}], basis::SymplecticBasis, r<:Real, theta<:Real, noise::Ts)
 
 Gaussian operator that squeezes a two-mode vacuum state into a two-mode squeezed state,
-known as the two-mode squeezing operator. The amplitude and phase squeezing parameters 
+known as the two-mode squeezing operator. The symplectic representation is given by `basis`. The amplitude and phase squeezing parameters 
 are given by `r` and `theta`, respectively. Noise can be added to the operation
 with `noise`.
 
@@ -241,11 +241,11 @@ function _twosqueeze(basis::QuadPairBasis{N}, r::R, theta::R) where {N<:Int,R<:V
 end
 
 """
-    phaseshift([Tm=Vector{Float64}, Ts=Matrix{Float64}], theta<:Real)
-    phaseshift([Tm=Vector{Float64}, Ts=Matrix{Float64}], theta<:Real, noise::Ts)
+    phaseshift([Tm=Vector{Float64}, Ts=Matrix{Float64}], basis::SymplecticBasis, theta<:Real)
+    phaseshift([Tm=Vector{Float64}, Ts=Matrix{Float64}], basis::SymplecticBasis, theta<:Real, noise::Ts)
 
 Gaussian operator that rotates the phase of a given Gaussian mode by `theta`,
-as the phase shift operator. Noise can be added to the operation
+as the phase shift operator. The symplectic representation is given by `basis`. Noise can be added to the operation
 with `noise`.
 
 ## Mathematical description of a phase shift operator
@@ -316,12 +316,12 @@ function _phaseshift(basis::QuadPairBasis{N}, theta::R) where {N<:Int,R<:Vector}
 end
 
 """
-    beamsplitter([Tm=Vector{Float64}, Ts=Matrix{Float64}], transmit<:Real)
-    beamsplitter([Tm=Vector{Float64}, Ts=Matrix{Float64}], transmit<:Real, noise::Ts)
+    beamsplitter([Tm=Vector{Float64}, Ts=Matrix{Float64}], basis::SymplecticBasis, transmit<:Real)
+    beamsplitter([Tm=Vector{Float64}, Ts=Matrix{Float64}], basis::SymplecticBasis, transmit<:Real, noise::Ts)
 
 Gaussian operator that serves as the beam splitter transformation of a
-two-mode Gaussian state, known as the beam splitter operator. The transmittivity
-of the operator is given by `transmit`. Noise can be added to the operation
+two-mode Gaussian state, known as the beam splitter operator. The symplectic representation is given
+by `basis`. The transmittivity of the operator is given by `transmit`. Noise can be added to the operation
 with `noise`.
 
 ## Mathematical description of a beam splitter operator

--- a/src/wigner.jl
+++ b/src/wigner.jl
@@ -1,33 +1,19 @@
 """
-    symplecticform([T = Matrix{Float64},] nmodes<:Int)
-
-Compute the symplectic form matrix of size 2N x 2N, where N is given by `nmodes`.
-"""
-function symplecticform(nmodes::N) where {N<:Int}
-    Omega = zeros(2*nmodes, 2*nmodes)
-    @inbounds for i in Base.OneTo(nmodes)
-        Omega[2*i-1, 2*i] = 1.0
-        Omega[2*i, 2*i-1] = -1.0
-    end
-    return Omega
-end
-symplecticform(::Type{T}, modes::N) where {T, N<:Int} = T(symplecticform(modes))
-
-"""
     wigner(state::GaussianState, x)
 
 Compute the Wigner function of an N-mode Gaussian state at `x`, a vector of size 2N.
 """
 function wigner(state::GaussianState, x::T) where {T}
+    repr = state.repr
+    nmodes = repr.nmodes
     mean = state.mean
     isequal(length(mean), length(x)) || throw(ArgumentError(WIGNER_ERROR))
 
     V = state.covar
-    modes = length(mean)/2
     diff = x .- mean
     arg = -(1/2) * transpose(diff) * inv(V) * diff
 
-    return exp(arg)/((2pi)^modes * sqrt(det(V)))
+    return exp(arg)/((2pi)^nmodes * sqrt(det(V)))
 end
 
 """
@@ -36,12 +22,13 @@ end
 Compute the Wigner characteristic function of an N-mode Gaussian state at `xi`, a vector of size 2N.
 """
 function wignerchar(state::GaussianState, xi::T) where {T}
+    repr = state.repr
+    nmodes = repr.nmodes
     mean = state.mean
     isequal(length(mean), length(xi)) || throw(ArgumentError(WIGNER_ERROR))
 
     V = state.covar
-    modes = Int(length(mean)/2)
-    Omega = symplecticform(modes)
+    Omega = symplecticform(repr)
 
     arg1 = -(1/2) * transpose(xi) * (Omega*V*transpose(Omega))*xi
     arg2 = im * transpose(Omega*mean) * xi

--- a/src/wigner.jl
+++ b/src/wigner.jl
@@ -4,8 +4,8 @@
 Compute the Wigner function of an N-mode Gaussian state at `x`, a vector of size 2N.
 """
 function wigner(state::GaussianState, x::T) where {T}
-    repr = state.repr
-    nmodes = repr.nmodes
+    basis = state.basis
+    nmodes = basis.nmodes
     mean = state.mean
     isequal(length(mean), length(x)) || throw(ArgumentError(WIGNER_ERROR))
 
@@ -22,13 +22,13 @@ end
 Compute the Wigner characteristic function of an N-mode Gaussian state at `xi`, a vector of size 2N.
 """
 function wignerchar(state::GaussianState, xi::T) where {T}
-    repr = state.repr
-    nmodes = repr.nmodes
+    basis = state.basis
+    nmodes = basis.nmodes
     mean = state.mean
     isequal(length(mean), length(xi)) || throw(ArgumentError(WIGNER_ERROR))
 
     V = state.covar
-    Omega = symplecticform(repr)
+    Omega = symplecticform(basis)
 
     arg1 = -(1/2) * transpose(xi) * (Omega*V*transpose(Omega))*xi
     arg2 = im * transpose(Omega*mean) * xi

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,7 @@ testfilter = ti -> begin
   exclude = Symbol[:jet]
   if !(VERSION >= v"1.10")
     push!(exclude, :doctests)
-    push!(exclude, :aqua)
+    push!(exclude, :aqua)                                 
   end
 
   return all(!in(exclude), ti.tags)

--- a/test/test_channels.jl
+++ b/test/test_channels.jl
@@ -114,6 +114,9 @@
         p = phaseshift(qpairbasis, theta, noise)
         @test tensor(tensor(p, d1), d2) == p ⊗ d1 ⊗ d2
 
+        p_block = phaseshift(qblockbasis, theta, T * noise * transpose(T))
+        p_blocks = phaseshift(2*qblockbasis, repeat([theta], 2*nmodes), T_ds * noise_ds * transpose(T_ds))
+        @test p_block ⊗ p_block == p_blocks
 
         dstatic = displace(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis, alpha1, noise)
         tpstatic = dstatic ⊗ dstatic ⊗ dstatic

--- a/test/test_channels.jl
+++ b/test/test_channels.jl
@@ -1,6 +1,9 @@
-@testitem "Channels" begin
+@testitem "CanonicalForm" begin
     using Gabs
     using StaticArrays
+
+    repr1 = CanonicalForm(1)
+    repr2 = CanonicalForm(2)
 
     noise2 = rand(Float64, (2,2))
     noise2_ds = [noise2 zeros(2,2); zeros(2,2) noise2]
@@ -8,69 +11,69 @@
 
     @testset "displacement operator" begin
         alpha = rand(ComplexF64)
-        @test displace(alpha, noise2) isa GaussianChannel
-        @test displace(SVector{2}, SMatrix{2,2}, alpha, noise2) isa GaussianChannel
-        @test displace(Array, alpha, noise2) isa GaussianChannel
+        @test displace(repr1, alpha, noise2) isa GaussianChannel
+        @test displace(SVector{2}, SMatrix{2,2}, repr1, alpha, noise2) isa GaussianChannel
+        @test displace(Array, repr1, alpha, noise2) isa GaussianChannel
     end
 
     @testset "squeeze operator" begin
         r, theta = rand(Float64), rand(Float64)
-        @test squeeze(r, theta, noise2) isa GaussianChannel
-        @test squeeze(SVector{2}, SMatrix{2,2}, r, theta, noise2) isa GaussianChannel
-        @test squeeze(Array, r, theta, noise2) isa GaussianChannel
+        @test squeeze(repr1, r, theta, noise2) isa GaussianChannel
+        @test squeeze(SVector{2}, SMatrix{2,2}, repr1, r, theta, noise2) isa GaussianChannel
+        @test squeeze(Array, repr1, r, theta, noise2) isa GaussianChannel
     end
 
     @testset "two-mode squeeze operator" begin
         r, theta = rand(Float64), rand(Float64)
-        @test twosqueeze(r, theta, noise4) isa GaussianChannel
-        @test twosqueeze(SVector{4}, SMatrix{4,4}, r, theta, noise4) isa GaussianChannel
-        @test twosqueeze(Array, r, theta, noise4) isa GaussianChannel
+        @test twosqueeze(repr2, r, theta, noise4) isa GaussianChannel
+        @test twosqueeze(SVector{4}, SMatrix{4,4}, repr2, r, theta, noise4) isa GaussianChannel
+        @test twosqueeze(Array, repr2, r, theta, noise4) isa GaussianChannel
     end
 
     @testset "phase-shift operator" begin
         theta = rand(Float64)
-        @test phaseshift(theta, noise2) isa GaussianChannel
-        @test phaseshift(SVector{2}, SMatrix{2,2}, theta, noise2) isa GaussianChannel
-        @test phaseshift(Array, theta, noise2) isa GaussianChannel
+        @test phaseshift(repr1, theta, noise2) isa GaussianChannel
+        @test phaseshift(SVector{2}, SMatrix{2,2}, repr1, theta, noise2) isa GaussianChannel
+        @test phaseshift(Array, repr1, theta, noise2) isa GaussianChannel
     end
 
     @testset "beamsplitter operator" begin
         theta = rand(Float64)
-        @test beamsplitter(theta, noise4) isa GaussianChannel
-        @test beamsplitter(SVector{4}, SMatrix{4,4}, theta, noise4) isa GaussianChannel
-        @test beamsplitter(Array, theta, noise4) isa GaussianChannel
+        @test beamsplitter(repr2, theta, noise4) isa GaussianChannel
+        @test beamsplitter(SVector{4}, SMatrix{4,4}, repr2, theta, noise4) isa GaussianChannel
+        @test beamsplitter(Array, repr2, theta, noise4) isa GaussianChannel
     end
 
     @testset "attenuator channel" begin
         theta = rand(Float64)
         n = rand(Int64)
-        @test attenuator(theta, n) isa GaussianChannel
-        @test attenuator(SVector{2}, SMatrix{2,2}, theta, n) isa GaussianChannel
-        @test attenuator(Array, theta, n) isa GaussianChannel
+        @test attenuator(repr1, theta, n) isa GaussianChannel
+        @test attenuator(SVector{2}, SMatrix{2,2}, repr1, theta, n) isa GaussianChannel
+        @test attenuator(Array, repr1, theta, n) isa GaussianChannel
     end
 
     @testset "amplifier channel" begin
         r = rand(Float64)
         n = rand(Int64)
-        @test amplifier(r, n) isa GaussianChannel
-        @test amplifier(SVector{2}, SMatrix{2,2}, r, n) isa GaussianChannel
-        @test amplifier(Array, r, n) isa GaussianChannel
+        @test amplifier(repr1, r, n) isa GaussianChannel
+        @test amplifier(SVector{2}, SMatrix{2,2}, repr1, r, n) isa GaussianChannel
+        @test amplifier(Array, repr1, r, n) isa GaussianChannel
     end
     
     @testset "tensor products" begin
         alpha1, alpha2 = rand(ComplexF64), rand(ComplexF64)
-        d1, d2 = displace(alpha1, noise2), displace(alpha2, noise2)
+        d1, d2 = displace(repr1, alpha1, noise2), displace(repr1, alpha2, noise2)
         ds = tensor(d1, d2)
         @test ds isa GaussianChannel
         @test ds == d1 ⊗ d2
         @test tensor(SVector{4}, SMatrix{4,4}, d1, d2) isa GaussianChannel
 
         r, theta = rand(Float64), rand(Float64)
-        p = phaseshift(theta, noise2)
+        p = phaseshift(repr1, theta, noise2)
         @test tensor(tensor(p, d1), d2) == p ⊗ d1 ⊗ d2
 
 
-        dstatic = displace(SVector{2}, SMatrix{2,2}, alpha1, noise2)
+        dstatic = displace(SVector{2}, SMatrix{2,2}, repr1, alpha1, noise2)
         tpstatic = dstatic ⊗ dstatic ⊗ dstatic
         @test tpstatic.disp isa SVector{6}
         @test tpstatic.transform isa SMatrix{6,6}
@@ -84,17 +87,17 @@
     @testset "actions" begin
         z = zeros(2,2)
         alpha = rand(ComplexF64)
-        d = displace(alpha, z)
-        v = vacuumstate()
-        c = coherentstate(alpha)
+        d = displace(repr1, alpha, z)
+        v = vacuumstate(repr1)
+        c = coherentstate(repr1, alpha)
         @test d * v == c
         @test isapprox(d * v, c)
         @test apply!(v, d) == c
 
-        v1, v2 = vacuumstate(), vacuumstate()
+        v1, v2 = vacuumstate(repr1), vacuumstate(repr1)
         alpha1, alpha2 = rand(ComplexF64), rand(ComplexF64)
-        d1, d2 = displace(alpha1, z), displace(alpha2, z)
-        c1, c2 = coherentstate(alpha1), coherentstate(alpha2)
+        d1, d2 = displace(repr1, alpha1, z), displace(repr1, alpha2, z)
+        c1, c2 = coherentstate(repr1, alpha1), coherentstate(repr1, alpha2)
         @test (d1 ⊗ d2) * (v1 ⊗ v2) == c1 ⊗ c2
     end
 end

--- a/test/test_channels.jl
+++ b/test/test_channels.jl
@@ -1,83 +1,109 @@
-@testitem "Quadrature pair basis" begin
+@testitem "Channels" begin
+    import Gabs: _changebasis
     using Gabs
     using StaticArrays
 
-    basis1 = QuadPairBasis(1)
-    basis2 = QuadPairBasis(2)
-
-    noise2 = rand(Float64, (2,2))
-    noise2_ds = [noise2 zeros(2,2); zeros(2,2) noise2]
-    noise4 = rand(Float64, (4,4))
+    nmodes = rand(1:5)
+    qpairbasis = QuadPairBasis(nmodes)
+    qblockbasis = QuadBlockBasis(nmodes)
+    noise = rand(2*nmodes, 2*nmodes)
+    noise_ds = [noise zeros(2*nmodes,2*nmodes); zeros(2*nmodes,2*nmodes) noise]
+    T = zeros(2*nmodes, 2*nmodes)
+    @inbounds for i in Base.OneTo(2*nmodes), j in Base.OneTo(2*nmodes)
+        if (j == 2*i-1) || (j + 2*nmodes == 2*i)
+            T[i,j] = 1
+        end
+    end
+    T_ds = zeros(4*nmodes, 4*nmodes)
+    @inbounds for i in Base.OneTo(4*nmodes), j in Base.OneTo(4*nmodes)
+        if (j == 2*i-1) || (j + 2*(2*nmodes) == 2*i)
+            T_ds[i,j] = 1
+        end
+    end
 
     @testset "displacement operator" begin
         alpha = rand(ComplexF64)
-        @test displace(basis1, alpha, noise2) isa GaussianChannel
-        @test displace(SVector{2}, SMatrix{2,2}, basis1, alpha, noise2) isa GaussianChannel
-        @test displace(Array, basis1, alpha, noise2) isa GaussianChannel
+        op = displace(qpairbasis, alpha, noise)
+        @test op isa GaussianChannel
+        @test displace(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis, alpha, noise) isa GaussianChannel
+        @test displace(Array, qpairbasis, alpha, noise) isa GaussianChannel
+        @test displace(qblockbasis, alpha, T*noise*transpose(T)) == _changebasis(op, QuadBlockBasis)
     end
 
     @testset "squeeze operator" begin
         r, theta = rand(Float64), rand(Float64)
-        @test squeeze(basis1, r, theta, noise2) isa GaussianChannel
-        @test squeeze(SVector{2}, SMatrix{2,2}, basis1, r, theta, noise2) isa GaussianChannel
-        @test squeeze(Array, basis1, r, theta, noise2) isa GaussianChannel
+        op = squeeze(qpairbasis, r, theta, noise)
+        @test op isa GaussianChannel
+        @test squeeze(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis, r, theta, noise) isa GaussianChannel
+        @test squeeze(Array, qpairbasis, r, theta, noise) isa GaussianChannel
+        @test squeeze(qblockbasis, r, theta, T*noise*transpose(T)) == _changebasis(op, QuadBlockBasis)
     end
 
     @testset "two-mode squeeze operator" begin
         r, theta = rand(Float64), rand(Float64)
-        @test twosqueeze(basis2, r, theta, noise4) isa GaussianChannel
-        @test twosqueeze(SVector{4}, SMatrix{4,4}, basis2, r, theta, noise4) isa GaussianChannel
-        @test twosqueeze(Array, basis2, r, theta, noise4) isa GaussianChannel
+        op = twosqueeze(2*qpairbasis, r, theta, noise_ds)
+        @test op isa GaussianChannel
+        @test twosqueeze(SVector{4*nmodes}, SMatrix{4*nmodes,4*nmodes}, 2*qpairbasis, r, theta, noise_ds) isa GaussianChannel
+        @test twosqueeze(Array, 2*qpairbasis, r, theta, noise_ds) isa GaussianChannel
+        @test twosqueeze(2*qblockbasis, r, theta, T_ds*noise_ds*transpose(T_ds)) == _changebasis(op, QuadBlockBasis)
     end
 
     @testset "phase-shift operator" begin
         theta = rand(Float64)
-        @test phaseshift(basis1, theta, noise2) isa GaussianChannel
-        @test phaseshift(SVector{2}, SMatrix{2,2}, basis1, theta, noise2) isa GaussianChannel
-        @test phaseshift(Array, basis1, theta, noise2) isa GaussianChannel
+        op = phaseshift(qpairbasis, theta, noise)
+        @test op isa GaussianChannel
+        @test phaseshift(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis, theta, noise) isa GaussianChannel
+        @test phaseshift(Array, qpairbasis, theta, noise) isa GaussianChannel
+        @test phaseshift(qblockbasis, theta, T*noise*transpose(T)) == _changebasis(op, QuadBlockBasis)
     end
 
     @testset "beamsplitter operator" begin
         theta = rand(Float64)
-        @test beamsplitter(basis2, theta, noise4) isa GaussianChannel
-        @test beamsplitter(SVector{4}, SMatrix{4,4}, basis2, theta, noise4) isa GaussianChannel
-        @test beamsplitter(Array, basis2, theta, noise4) isa GaussianChannel
+        op = beamsplitter(2*qpairbasis, theta, noise_ds)
+        @test op isa GaussianChannel
+        @test beamsplitter(SVector{4*nmodes}, SMatrix{4*nmodes,4*nmodes}, 2*qpairbasis, theta, noise_ds) isa GaussianChannel
+        @test beamsplitter(Array, 2*qpairbasis, theta, noise_ds) isa GaussianChannel
+        @test beamsplitter(2*qblockbasis, theta, T_ds*noise_ds*transpose(T_ds)) == _changebasis(op, QuadBlockBasis)
     end
 
     @testset "attenuator channel" begin
         theta = rand(Float64)
         n = rand(Int64)
-        @test attenuator(basis1, theta, n) isa GaussianChannel
-        @test attenuator(SVector{2}, SMatrix{2,2}, basis1, theta, n) isa GaussianChannel
-        @test attenuator(Array, basis1, theta, n) isa GaussianChannel
+        op = attenuator(qpairbasis, theta, n)
+        @test op isa GaussianChannel
+        @test attenuator(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis, theta, n) isa GaussianChannel
+        @test attenuator(Array, qpairbasis, theta, n) isa GaussianChannel
+        @test attenuator(qblockbasis, theta, n) == _changebasis(op, QuadBlockBasis)
     end
 
     @testset "amplifier channel" begin
         r = rand(Float64)
         n = rand(Int64)
-        @test amplifier(basis1, r, n) isa GaussianChannel
-        @test amplifier(SVector{2}, SMatrix{2,2}, basis1, r, n) isa GaussianChannel
-        @test amplifier(Array, basis1, r, n) isa GaussianChannel
+        op = amplifier(qpairbasis, r, n)
+        @test op isa GaussianChannel
+        @test amplifier(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis, r, n) isa GaussianChannel
+        @test amplifier(Array, qpairbasis, r, n) isa GaussianChannel
+        @test amplifier(qblockbasis, r, n) == _changebasis(op, QuadBlockBasis)
     end
     
     @testset "tensor products" begin
         alpha1, alpha2 = rand(ComplexF64), rand(ComplexF64)
-        d1, d2 = displace(basis1, alpha1, noise2), displace(basis1, alpha2, noise2)
+        d1, d2 = displace(qpairbasis, alpha1, noise), displace(qpairbasis, alpha2, noise)
         ds = tensor(d1, d2)
         @test ds isa GaussianChannel
         @test ds == d1 ⊗ d2
-        @test tensor(SVector{4}, SMatrix{4,4}, d1, d2) isa GaussianChannel
+        @test tensor(SVector{4*nmodes}, SMatrix{4*nmodes,4*nmodes}, d1, d2) isa GaussianChannel
 
         r, theta = rand(Float64), rand(Float64)
-        p = phaseshift(basis1, theta, noise2)
+        p = phaseshift(qpairbasis, theta, noise)
         @test tensor(tensor(p, d1), d2) == p ⊗ d1 ⊗ d2
 
 
-        dstatic = displace(SVector{2}, SMatrix{2,2}, basis1, alpha1, noise2)
+        dstatic = displace(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis, alpha1, noise)
         tpstatic = dstatic ⊗ dstatic ⊗ dstatic
-        @test tpstatic.disp isa SVector{6}
-        @test tpstatic.transform isa SMatrix{6,6}
-        @test tpstatic.noise isa SMatrix{6,6}
+        @test tpstatic.disp isa SVector{6*nmodes}
+        @test tpstatic.transform isa SMatrix{6*nmodes,6*nmodes}
+        @test tpstatic.noise isa SMatrix{6*nmodes,6*nmodes}
         tp = dstatic ⊗ d1 ⊗ dstatic
         @test tp.disp isa Vector
         @test tp.transform isa Matrix
@@ -85,19 +111,19 @@
     end
 
     @testset "actions" begin
-        z = zeros(2,2)
+        z = zeros(2*nmodes,2*nmodes)
         alpha = rand(ComplexF64)
-        d = displace(basis1, alpha, z)
-        v = vacuumstate(basis1)
-        c = coherentstate(basis1, alpha)
+        d = displace(qpairbasis, alpha, z)
+        v = vacuumstate(qpairbasis)
+        c = coherentstate(qpairbasis, alpha)
         @test d * v == c
         @test isapprox(d * v, c)
         @test apply!(v, d) == c
 
-        v1, v2 = vacuumstate(basis1), vacuumstate(basis1)
+        v1, v2 = vacuumstate(qpairbasis), vacuumstate(qpairbasis)
         alpha1, alpha2 = rand(ComplexF64), rand(ComplexF64)
-        d1, d2 = displace(basis1, alpha1, z), displace(basis1, alpha2, z)
-        c1, c2 = coherentstate(basis1, alpha1), coherentstate(basis1, alpha2)
+        d1, d2 = displace(qpairbasis, alpha1, z), displace(qpairbasis, alpha2, z)
+        c1, c2 = coherentstate(qpairbasis, alpha1), coherentstate(qpairbasis, alpha2)
         @test (d1 ⊗ d2) * (v1 ⊗ v2) == c1 ⊗ c2
     end
 end

--- a/test/test_channels.jl
+++ b/test/test_channels.jl
@@ -23,67 +23,83 @@
 
     @testset "displacement operator" begin
         alpha = rand(ComplexF64)
+        alphas = rand(ComplexF64, nmodes)
         op = displace(qpairbasis, alpha, noise)
         @test op isa GaussianChannel
         @test displace(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis, alpha, noise) isa GaussianChannel
         @test displace(Array, qpairbasis, alpha, noise) isa GaussianChannel
         @test displace(qblockbasis, alpha, T*noise*transpose(T)) == _changebasis(op, QuadBlockBasis)
+        @test displace(qblockbasis, alphas, T*noise*transpose(T)) == _changebasis(displace(qpairbasis, alphas, noise), QuadBlockBasis)
     end
 
     @testset "squeeze operator" begin
         r, theta = rand(Float64), rand(Float64)
+        rs, thetas = rand(Float64, nmodes), rand(Float64, nmodes)
         op = squeeze(qpairbasis, r, theta, noise)
         @test op isa GaussianChannel
         @test squeeze(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis, r, theta, noise) isa GaussianChannel
         @test squeeze(Array, qpairbasis, r, theta, noise) isa GaussianChannel
         @test squeeze(qblockbasis, r, theta, T*noise*transpose(T)) == _changebasis(op, QuadBlockBasis)
+        @test squeeze(qblockbasis, rs, thetas, T*noise*transpose(T)) == _changebasis(squeeze(qpairbasis, rs, thetas, noise), QuadBlockBasis)
     end
 
     @testset "two-mode squeeze operator" begin
         r, theta = rand(Float64), rand(Float64)
+        rs, thetas = rand(Float64, nmodes), rand(Float64, nmodes)
         op = twosqueeze(2*qpairbasis, r, theta, noise_ds)
         @test op isa GaussianChannel
         @test twosqueeze(SVector{4*nmodes}, SMatrix{4*nmodes,4*nmodes}, 2*qpairbasis, r, theta, noise_ds) isa GaussianChannel
         @test twosqueeze(Array, 2*qpairbasis, r, theta, noise_ds) isa GaussianChannel
         @test twosqueeze(2*qblockbasis, r, theta, T_ds*noise_ds*transpose(T_ds)) == _changebasis(op, QuadBlockBasis)
+        @test twosqueeze(2*qblockbasis, rs, thetas, T_ds*noise_ds*transpose(T_ds)) == _changebasis(twosqueeze(2*qpairbasis, rs, thetas, noise_ds), QuadBlockBasis)
     end
 
     @testset "phase-shift operator" begin
         theta = rand(Float64)
+        thetas = rand(Float64, nmodes)
         op = phaseshift(qpairbasis, theta, noise)
         @test op isa GaussianChannel
         @test phaseshift(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis, theta, noise) isa GaussianChannel
         @test phaseshift(Array, qpairbasis, theta, noise) isa GaussianChannel
         @test phaseshift(qblockbasis, theta, T*noise*transpose(T)) == _changebasis(op, QuadBlockBasis)
+        @test phaseshift(qblockbasis, thetas, T*noise*transpose(T)) == _changebasis(phaseshift(qpairbasis, thetas, noise), QuadBlockBasis)
     end
 
     @testset "beamsplitter operator" begin
         theta = rand(Float64)
+        thetas = rand(Float64, nmodes)
         op = beamsplitter(2*qpairbasis, theta, noise_ds)
         @test op isa GaussianChannel
         @test beamsplitter(SVector{4*nmodes}, SMatrix{4*nmodes,4*nmodes}, 2*qpairbasis, theta, noise_ds) isa GaussianChannel
         @test beamsplitter(Array, 2*qpairbasis, theta, noise_ds) isa GaussianChannel
         @test beamsplitter(2*qblockbasis, theta, T_ds*noise_ds*transpose(T_ds)) == _changebasis(op, QuadBlockBasis)
+        @test beamsplitter(2*qblockbasis, thetas, T_ds*noise_ds*transpose(T_ds)) == _changebasis(beamsplitter(2*qpairbasis, thetas, noise_ds), QuadBlockBasis)
     end
 
     @testset "attenuator channel" begin
         theta = rand(Float64)
+        thetas = rand(Float64, nmodes)
         n = rand(Int64)
+        ns = rand(Int64, nmodes)
         op = attenuator(qpairbasis, theta, n)
         @test op isa GaussianChannel
         @test attenuator(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis, theta, n) isa GaussianChannel
         @test attenuator(Array, qpairbasis, theta, n) isa GaussianChannel
         @test attenuator(qblockbasis, theta, n) == _changebasis(op, QuadBlockBasis)
+        @test attenuator(qblockbasis, thetas, ns) == _changebasis(attenuator(qpairbasis, thetas, ns), QuadBlockBasis)
     end
 
     @testset "amplifier channel" begin
         r = rand(Float64)
+        rs = rand(Float64, nmodes)
         n = rand(Int64)
+        ns = rand(Float64, nmodes)
         op = amplifier(qpairbasis, r, n)
         @test op isa GaussianChannel
         @test amplifier(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis, r, n) isa GaussianChannel
         @test amplifier(Array, qpairbasis, r, n) isa GaussianChannel
         @test amplifier(qblockbasis, r, n) == _changebasis(op, QuadBlockBasis)
+        @test amplifier(qblockbasis, rs, ns) == _changebasis(amplifier(qpairbasis, rs, ns), QuadBlockBasis)
     end
     
     @testset "tensor products" begin

--- a/test/test_channels.jl
+++ b/test/test_channels.jl
@@ -1,9 +1,9 @@
-@testitem "CanonicalForm" begin
+@testitem "Quadrature pair basis" begin
     using Gabs
     using StaticArrays
 
-    repr1 = CanonicalForm(1)
-    repr2 = CanonicalForm(2)
+    basis1 = QuadPairBasis(1)
+    basis2 = QuadPairBasis(2)
 
     noise2 = rand(Float64, (2,2))
     noise2_ds = [noise2 zeros(2,2); zeros(2,2) noise2]
@@ -11,69 +11,69 @@
 
     @testset "displacement operator" begin
         alpha = rand(ComplexF64)
-        @test displace(repr1, alpha, noise2) isa GaussianChannel
-        @test displace(SVector{2}, SMatrix{2,2}, repr1, alpha, noise2) isa GaussianChannel
-        @test displace(Array, repr1, alpha, noise2) isa GaussianChannel
+        @test displace(basis1, alpha, noise2) isa GaussianChannel
+        @test displace(SVector{2}, SMatrix{2,2}, basis1, alpha, noise2) isa GaussianChannel
+        @test displace(Array, basis1, alpha, noise2) isa GaussianChannel
     end
 
     @testset "squeeze operator" begin
         r, theta = rand(Float64), rand(Float64)
-        @test squeeze(repr1, r, theta, noise2) isa GaussianChannel
-        @test squeeze(SVector{2}, SMatrix{2,2}, repr1, r, theta, noise2) isa GaussianChannel
-        @test squeeze(Array, repr1, r, theta, noise2) isa GaussianChannel
+        @test squeeze(basis1, r, theta, noise2) isa GaussianChannel
+        @test squeeze(SVector{2}, SMatrix{2,2}, basis1, r, theta, noise2) isa GaussianChannel
+        @test squeeze(Array, basis1, r, theta, noise2) isa GaussianChannel
     end
 
     @testset "two-mode squeeze operator" begin
         r, theta = rand(Float64), rand(Float64)
-        @test twosqueeze(repr2, r, theta, noise4) isa GaussianChannel
-        @test twosqueeze(SVector{4}, SMatrix{4,4}, repr2, r, theta, noise4) isa GaussianChannel
-        @test twosqueeze(Array, repr2, r, theta, noise4) isa GaussianChannel
+        @test twosqueeze(basis2, r, theta, noise4) isa GaussianChannel
+        @test twosqueeze(SVector{4}, SMatrix{4,4}, basis2, r, theta, noise4) isa GaussianChannel
+        @test twosqueeze(Array, basis2, r, theta, noise4) isa GaussianChannel
     end
 
     @testset "phase-shift operator" begin
         theta = rand(Float64)
-        @test phaseshift(repr1, theta, noise2) isa GaussianChannel
-        @test phaseshift(SVector{2}, SMatrix{2,2}, repr1, theta, noise2) isa GaussianChannel
-        @test phaseshift(Array, repr1, theta, noise2) isa GaussianChannel
+        @test phaseshift(basis1, theta, noise2) isa GaussianChannel
+        @test phaseshift(SVector{2}, SMatrix{2,2}, basis1, theta, noise2) isa GaussianChannel
+        @test phaseshift(Array, basis1, theta, noise2) isa GaussianChannel
     end
 
     @testset "beamsplitter operator" begin
         theta = rand(Float64)
-        @test beamsplitter(repr2, theta, noise4) isa GaussianChannel
-        @test beamsplitter(SVector{4}, SMatrix{4,4}, repr2, theta, noise4) isa GaussianChannel
-        @test beamsplitter(Array, repr2, theta, noise4) isa GaussianChannel
+        @test beamsplitter(basis2, theta, noise4) isa GaussianChannel
+        @test beamsplitter(SVector{4}, SMatrix{4,4}, basis2, theta, noise4) isa GaussianChannel
+        @test beamsplitter(Array, basis2, theta, noise4) isa GaussianChannel
     end
 
     @testset "attenuator channel" begin
         theta = rand(Float64)
         n = rand(Int64)
-        @test attenuator(repr1, theta, n) isa GaussianChannel
-        @test attenuator(SVector{2}, SMatrix{2,2}, repr1, theta, n) isa GaussianChannel
-        @test attenuator(Array, repr1, theta, n) isa GaussianChannel
+        @test attenuator(basis1, theta, n) isa GaussianChannel
+        @test attenuator(SVector{2}, SMatrix{2,2}, basis1, theta, n) isa GaussianChannel
+        @test attenuator(Array, basis1, theta, n) isa GaussianChannel
     end
 
     @testset "amplifier channel" begin
         r = rand(Float64)
         n = rand(Int64)
-        @test amplifier(repr1, r, n) isa GaussianChannel
-        @test amplifier(SVector{2}, SMatrix{2,2}, repr1, r, n) isa GaussianChannel
-        @test amplifier(Array, repr1, r, n) isa GaussianChannel
+        @test amplifier(basis1, r, n) isa GaussianChannel
+        @test amplifier(SVector{2}, SMatrix{2,2}, basis1, r, n) isa GaussianChannel
+        @test amplifier(Array, basis1, r, n) isa GaussianChannel
     end
     
     @testset "tensor products" begin
         alpha1, alpha2 = rand(ComplexF64), rand(ComplexF64)
-        d1, d2 = displace(repr1, alpha1, noise2), displace(repr1, alpha2, noise2)
+        d1, d2 = displace(basis1, alpha1, noise2), displace(basis1, alpha2, noise2)
         ds = tensor(d1, d2)
         @test ds isa GaussianChannel
         @test ds == d1 ⊗ d2
         @test tensor(SVector{4}, SMatrix{4,4}, d1, d2) isa GaussianChannel
 
         r, theta = rand(Float64), rand(Float64)
-        p = phaseshift(repr1, theta, noise2)
+        p = phaseshift(basis1, theta, noise2)
         @test tensor(tensor(p, d1), d2) == p ⊗ d1 ⊗ d2
 
 
-        dstatic = displace(SVector{2}, SMatrix{2,2}, repr1, alpha1, noise2)
+        dstatic = displace(SVector{2}, SMatrix{2,2}, basis1, alpha1, noise2)
         tpstatic = dstatic ⊗ dstatic ⊗ dstatic
         @test tpstatic.disp isa SVector{6}
         @test tpstatic.transform isa SMatrix{6,6}
@@ -87,17 +87,17 @@
     @testset "actions" begin
         z = zeros(2,2)
         alpha = rand(ComplexF64)
-        d = displace(repr1, alpha, z)
-        v = vacuumstate(repr1)
-        c = coherentstate(repr1, alpha)
+        d = displace(basis1, alpha, z)
+        v = vacuumstate(basis1)
+        c = coherentstate(basis1, alpha)
         @test d * v == c
         @test isapprox(d * v, c)
         @test apply!(v, d) == c
 
-        v1, v2 = vacuumstate(repr1), vacuumstate(repr1)
+        v1, v2 = vacuumstate(basis1), vacuumstate(basis1)
         alpha1, alpha2 = rand(ComplexF64), rand(ComplexF64)
-        d1, d2 = displace(repr1, alpha1, z), displace(repr1, alpha2, z)
-        c1, c2 = coherentstate(repr1, alpha1), coherentstate(repr1, alpha2)
+        d1, d2 = displace(basis1, alpha1, z), displace(basis1, alpha2, z)
+        c1, c2 = coherentstate(basis1, alpha1), coherentstate(basis1, alpha2)
         @test (d1 ⊗ d2) * (v1 ⊗ v2) == c1 ⊗ c2
     end
 end

--- a/test/test_measurements.jl
+++ b/test/test_measurements.jl
@@ -3,33 +3,34 @@
     using StaticArrays
     using LinearAlgebra: det
 
-    @testset "generaldyne" begin    
-        vac = vacuumstate()
+    @testset "generaldyne" begin
+        repr = CanonicalForm(1)
+        vac = vacuumstate(repr)
         vacs = vac ⊗ vac ⊗ vac ⊗ vac
         gd1 = Generaldyne(vacs, vac ⊗ vac, [2, 4])
         out1 = output(gd1)
         @test isequal(out1, vac ⊗ vac)
 
-        coh = coherentstate(1.0+im)
+        coh = coherentstate(repr, 1.0+im)
         cohs = coh ⊗ vac ⊗ coh ⊗ vac
-        epr = eprstate(1.0, 3.0)
+        epr = eprstate(repr + repr, 1.0, 3.0)
         gd2 = Generaldyne(cohs, epr, [1, 4])
         out2 = output(gd2)
         @test isequal(out2, vac ⊗ coh)
         out2_prob = exp(transpose(epr.mean .- (coh ⊗ vac).mean) * (inv(epr.covar .+ (coh ⊗ vac).covar) * (epr.mean .- (coh ⊗ vac).mean)))/(pi^2 * sqrt(det(epr.covar .+ (coh ⊗ vac).covar)))
         @test isapprox(prob(gd2), out2_prob)
 
-        state = GaussianState(Vector{Float64}(collect(1:4)), Matrix{Float64}(reshape(collect(1:16), (4,4))))
-        meas = GaussianState(Vector{Float64}(collect(1:2)), Matrix{Float64}(reshape(collect(1:4), (2,2))))
+        state = GaussianState(2*repr, Vector{Float64}(collect(1:4)), Matrix{Float64}(reshape(collect(1:16), (4,4))))
+        meas = GaussianState(repr, Vector{Float64}(collect(1:2)), Matrix{Float64}(reshape(collect(1:4), (2,2))))
         gd3 = Generaldyne(state, meas, [2])
         out3 = output(gd3)
         xA, xB = [1.0, 2.0], [3.0, 4.0]
         VA, VB, VAB = [1.0 5.0; 2.0 6.0], [11.0 15.0; 12.0 16.0], [9.0 13.0; 10.0 14.0]
         out3_mean = xA .+ VAB*((inv(VB .+ meas.covar))*(meas.mean .- xB))
         out3_covar = VA .- VAB*((inv(VB .+ meas.covar))*transpose(VAB))
-        @test isapprox(out3, GaussianState(out3_mean, out3_covar))
+        @test isapprox(out3, GaussianState(repr, out3_mean, out3_covar))
 
-        sstatic = vacuumstate(SVector{2}, SMatrix{2,2})
+        sstatic = vacuumstate(SVector{2}, SMatrix{2,2}, repr)
         statestatic = sstatic ⊗ sstatic ⊗ sstatic ⊗ sstatic
         gdstatic = Generaldyne(statestatic, sstatic, [2])
         outstatic = output(gdstatic)

--- a/test/test_measurements.jl
+++ b/test/test_measurements.jl
@@ -4,33 +4,33 @@
     using LinearAlgebra: det
 
     @testset "generaldyne" begin
-        repr = CanonicalForm(1)
-        vac = vacuumstate(repr)
+        basis = QuadPairBasis(1)
+        vac = vacuumstate(basis)
         vacs = vac ⊗ vac ⊗ vac ⊗ vac
         gd1 = Generaldyne(vacs, vac ⊗ vac, [2, 4])
         out1 = output(gd1)
         @test isequal(out1, vac ⊗ vac)
 
-        coh = coherentstate(repr, 1.0+im)
+        coh = coherentstate(basis, 1.0+im)
         cohs = coh ⊗ vac ⊗ coh ⊗ vac
-        epr = eprstate(repr + repr, 1.0, 3.0)
+        epr = eprstate(basis + basis, 1.0, 3.0)
         gd2 = Generaldyne(cohs, epr, [1, 4])
         out2 = output(gd2)
         @test isequal(out2, vac ⊗ coh)
         out2_prob = exp(transpose(epr.mean .- (coh ⊗ vac).mean) * (inv(epr.covar .+ (coh ⊗ vac).covar) * (epr.mean .- (coh ⊗ vac).mean)))/(pi^2 * sqrt(det(epr.covar .+ (coh ⊗ vac).covar)))
         @test isapprox(prob(gd2), out2_prob)
 
-        state = GaussianState(2*repr, Vector{Float64}(collect(1:4)), Matrix{Float64}(reshape(collect(1:16), (4,4))))
-        meas = GaussianState(repr, Vector{Float64}(collect(1:2)), Matrix{Float64}(reshape(collect(1:4), (2,2))))
+        state = GaussianState(2*basis, Vector{Float64}(collect(1:4)), Matrix{Float64}(reshape(collect(1:16), (4,4))))
+        meas = GaussianState(basis, Vector{Float64}(collect(1:2)), Matrix{Float64}(reshape(collect(1:4), (2,2))))
         gd3 = Generaldyne(state, meas, [2])
         out3 = output(gd3)
         xA, xB = [1.0, 2.0], [3.0, 4.0]
         VA, VB, VAB = [1.0 5.0; 2.0 6.0], [11.0 15.0; 12.0 16.0], [9.0 13.0; 10.0 14.0]
         out3_mean = xA .+ VAB*((inv(VB .+ meas.covar))*(meas.mean .- xB))
         out3_covar = VA .- VAB*((inv(VB .+ meas.covar))*transpose(VAB))
-        @test isapprox(out3, GaussianState(repr, out3_mean, out3_covar))
+        @test isapprox(out3, GaussianState(basis, out3_mean, out3_covar))
 
-        sstatic = vacuumstate(SVector{2}, SMatrix{2,2}, repr)
+        sstatic = vacuumstate(SVector{2}, SMatrix{2,2}, basis)
         statestatic = sstatic ⊗ sstatic ⊗ sstatic ⊗ sstatic
         gdstatic = Generaldyne(statestatic, sstatic, [2])
         outstatic = output(gdstatic)

--- a/test/test_randoms.jl
+++ b/test/test_randoms.jl
@@ -1,102 +1,117 @@
-@testitem "Quadrature pair basis" begin
+@testitem "Random objects" begin
     using Gabs
     using StaticArrays
     using LinearAlgebra: eigvals, adjoint
 
     @testset "random utils" begin
         nmodes = rand(1:20)
-        basis = QuadPairBasis(nmodes)
-        U = Gabs._rand_unitary(basis)
-        @test isapprox(adjoint(U), inv(U), atol = 1e-5)
+        qpairbasis = QuadPairBasis(nmodes)
+        qblockbasis = QuadBlockBasis(nmodes)
+        U_qpair = Gabs._rand_unitary(qpairbasis)
+        U_qblock = Gabs._rand_unitary(qblockbasis)
+        @test isapprox(adjoint(U_qpair), inv(U_qpair), atol = 1e-5)
+        @test isapprox(adjoint(U_qblock), inv(U_qblock), atol = 1e-5)
 
-        O = Gabs._rand_orthogonal_symplectic(basis)
-        @test isapprox(O', inv(O), atol = 1e-5)
-        Omega = symplecticform(basis)
-        @test isapprox(O' * Omega * O, Omega, atol = 1e-5)
+        O_qpair = Gabs._rand_orthogonal_symplectic(qpairbasis)
+        O_qblock = Gabs._rand_orthogonal_symplectic(qblockbasis)
+        @test isapprox(O_qpair', inv(O_qpair), atol = 1e-5)
+        @test isapprox(O_qblock', inv(O_qblock), atol = 1e-5)
+        Omega_qpair = symplecticform(qpairbasis)
+        Omega_qblock= symplecticform(qblockbasis)
+        @test isapprox(O_qpair' * Omega_qpair * O_qpair, Omega_qpair, atol = 1e-5)
+        @test isapprox(O_qblock' * Omega_qblock * O_qblock, Omega_qblock, atol = 1e-5)
 
-        Spassive = randsymplectic(basis, passive = true)
-        @test isapprox(Spassive', inv(Spassive), atol = 1e-5)
-        @test isapprox(Spassive' * Omega * Spassive, Omega, atol = 1e-5)
+        Spassive_qpair = randsymplectic(qpairbasis, passive = true)
+        Spassive_qblock = randsymplectic(qblockbasis, passive = true)
+        @test isapprox(Spassive_qpair', inv(Spassive_qpair), atol = 1e-5)
+        @test isapprox(Spassive_qpair' * Omega_qpair * Spassive_qpair, Omega_qpair, atol = 1e-5)
+        @test isapprox(Spassive_qblock', inv(Spassive_qblock), atol = 1e-5)
+        @test isapprox(Spassive_qblock' * Omega_qblock * Spassive_qblock, Omega_qblock, atol = 1e-5)
 
-        S = randsymplectic(basis)
-        @test isapprox(S' * Omega * S, Omega, atol = 1e-5)
+        S_qpair = randsymplectic(qpairbasis)
+        S_qblock = randsymplectic(qblockbasis)
+        @test isapprox(S_qpair' * Omega_qpair * S_qpair, Omega_qpair, atol = 1e-5)
+        @test isapprox(S_qblock' * Omega_qblock * S_qblock, Omega_qblock, atol = 1e-5)
 
-        S_array = randsymplectic(Array, basis)
-        @test isapprox(S_array' * Omega * S_array, Omega, atol = 1e-5)
+        S_array = randsymplectic(Array, qpairbasis)
+        @test isapprox(S_array' * Omega_qpair * S_array, Omega_qpair, atol = 1e-5)
     end
 
     @testset "random states" begin
         nmodes = rand(1:20)
-        basis = QuadPairBasis(nmodes)
-        rs = randstate(basis)
-        rc = randchannel(basis)
+        qpairbasis = QuadPairBasis(nmodes)
+        qblockbasis = QuadBlockBasis(nmodes)
+        rs = randstate(qpairbasis)
+        rc = randchannel(qpairbasis)
         @test rc isa GaussianChannel
         @test rc * rs isa GaussianState
-        Omega = symplecticform(basis)
+        Omega = symplecticform(qpairbasis)
         @test all(i -> ((i >= 0) || isapprox(i, 0.0, atol = 1e-5)), real(eigvals(rs.covar .+ im*Omega)))
 
-        rspure = randstate(basis, pure = true)
+        rspure = randstate(qpairbasis, pure = true)
         @test all(i -> ((i >= 0) || isapprox(i, 0.0, atol = 1e-5)), real(eigvals(rspure.covar .+ im*Omega)))
         @test isapprox(purity(rspure), 1.0, atol = 1e-5)
 
-        rs_array = randstate(Array, basis)
-        rc_array = randchannel(Array, basis)
+        rs_array = randstate(Array, qpairbasis)
+        rc_array = randchannel(Array, qpairbasis)
         @test rc_array isa GaussianChannel
         @test rc_array * rs_array isa GaussianState
         @test all(i -> ((i >= 0) || isapprox(i, 0.0, atol = 1e-5)), real(eigvals(rs_array.covar .+ im*Omega)))
 
-        rspure_array = randstate(Array, basis, pure = true)
+        rspure_array = randstate(Array, qpairbasis, pure = true)
         @test all(i -> ((i >= 0) || isapprox(i, 0.0, atol = 1e-3)), real(eigvals(rspure_array.covar .+ im*Omega)))
         @test isapprox(purity(rspure_array), 1.0, atol = 1e-3)
 
-        rs_static = randstate(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, basis)
-        rc_static = randchannel(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, basis)
+        rs_static = randstate(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis)
+        rc_static = randchannel(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis)
         @test rc_static isa GaussianChannel
         @test rc_static * rs_static isa GaussianState
         @test all(i -> ((i >= 0) || isapprox(i, 0.0, atol = 1e-5)), real(eigvals(Array(rs_static.covar) .+ im*Omega)))
 
-        rspure_static = randstate(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, basis, pure = true)
+        rspure_static = randstate(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis, pure = true)
         @test all(i -> ((i >= 0) || isapprox(i, 0.0, atol = 1e-5)), real(eigvals(Array(rspure_static.covar) .+ im*Omega)))
         @test isapprox(purity(rspure_static), 1.0, atol = 1e-5)
     end
 
     @testset "random unitaries" begin
         nmodes = rand(1:20)
-        basis = QuadPairBasis(nmodes)
-        ru = randunitary(basis)
-        Omega = symplecticform(basis)
+        qpairbasis = QuadPairBasis(nmodes)
+        qblockbasis = QuadBlockBasis(nmodes)
+        ru = randunitary(qpairbasis)
+        Omega = symplecticform(qpairbasis)
         @test isapprox(ru.symplectic' * Omega * ru.symplectic, Omega, atol = 1e-5)
 
-        rupassive = randunitary(basis, passive = true)
+        rupassive = randunitary(qpairbasis, passive = true)
         @test isapprox(rupassive.symplectic', inv(rupassive.symplectic), atol = 1e-5)
         @test isapprox(rupassive.symplectic' * Omega * rupassive.symplectic, Omega, atol = 1e-5)
 
-        ru_array = randunitary(Array, basis)
+        ru_array = randunitary(Array, qpairbasis)
         @test isapprox(ru_array.symplectic' * Omega * ru_array.symplectic, Omega, atol = 1e-5)
 
-        rupassive_array = randunitary(basis, passive = true)
+        rupassive_array = randunitary(qpairbasis, passive = true)
         @test isapprox(rupassive_array.symplectic', inv(rupassive_array.symplectic), atol = 1e-5)
         @test isapprox(rupassive_array.symplectic' * Omega * rupassive_array.symplectic, Omega, atol = 1e-5)
 
-        ru_static = randunitary(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, basis)
+        ru_static = randunitary(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis)
         @test isapprox(ru_static.symplectic' * Omega * ru_static.symplectic, Omega, atol = 1e-5)
 
-        rupassive_static = randunitary(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, basis, passive = true)
+        rupassive_static = randunitary(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis, passive = true)
         @test isapprox(rupassive_static.symplectic', inv(rupassive_static.symplectic), atol = 1e-5)
         @test isapprox(rupassive_static.symplectic' * Omega * rupassive_static.symplectic, Omega, atol = 1e-5)
     end
 
     @testset "random channels" begin
         nmodes = rand(1:20)
-        basis = QuadPairBasis(nmodes)
-        rc = randchannel(basis)
-        Omega = symplecticform(basis)
+        qpairbasis = QuadPairBasis(nmodes)
+        qblockbasis = QuadBlockBasis(nmodes)
+        rc = randchannel(qpairbasis)
+        Omega = symplecticform(qpairbasis)
         @test all(i -> ((i >= 0) || isapprox(i, 0.0, atol = 1e-5)), real(eigvals(rc.noise .+ im*Omega .- im*rc.transform*Omega*rc.transform')))
 
-        rc_array = randchannel(Array, basis)
+        rc_array = randchannel(Array, qpairbasis)
         @test all(i -> ((i >= 0) || isapprox(i, 0.0, atol = 1e-5)), real(eigvals(rc_array.noise .+ im*Omega .- im*rc_array.transform*Omega*rc_array.transform')))
 
-        rc_static = randchannel(SVector{2*nmodes}, SMatrix{2*nmodes, 2*nmodes}, basis)
+        rc_static = randchannel(SVector{2*nmodes}, SMatrix{2*nmodes, 2*nmodes}, qpairbasis)
         @test all(i -> ((i >= 0) || isapprox(i, 0.0, atol = 1e-5)), real(eigvals(Array(rc_static.noise) .+ im*Omega .- im*Array(rc_static.transform)*Omega*Array(rc_static.transform)')))
     end
 end

--- a/test/test_randoms.jl
+++ b/test/test_randoms.jl
@@ -1,98 +1,102 @@
-@testitem "Measurements" begin
+@testitem "CanonicalForm" begin
     using Gabs
     using StaticArrays
     using LinearAlgebra: eigvals, adjoint
 
     @testset "random utils" begin
         nmodes = rand(1:20)
-        U = Gabs._rand_unitary(nmodes)
+        repr = CanonicalForm(nmodes)
+        U = Gabs._rand_unitary(repr)
         @test isapprox(adjoint(U), inv(U), atol = 1e-5)
 
-        O = Gabs._rand_orthogonal_symplectic(nmodes)
+        O = Gabs._rand_orthogonal_symplectic(repr)
         @test isapprox(O', inv(O), atol = 1e-5)
-        Omega = symplecticform(nmodes)
+        Omega = symplecticform(repr)
         @test isapprox(O' * Omega * O, Omega, atol = 1e-5)
 
-        Spassive = randsymplectic(nmodes, passive = true)
+        Spassive = randsymplectic(repr, passive = true)
         @test isapprox(Spassive', inv(Spassive), atol = 1e-5)
         @test isapprox(Spassive' * Omega * Spassive, Omega, atol = 1e-5)
 
-        S = randsymplectic(nmodes)
+        S = randsymplectic(repr)
         @test isapprox(S' * Omega * S, Omega, atol = 1e-5)
 
-        S_array = randsymplectic(Array, nmodes)
+        S_array = randsymplectic(Array, repr)
         @test isapprox(S_array' * Omega * S_array, Omega, atol = 1e-5)
     end
 
     @testset "random states" begin
         nmodes = rand(1:20)
-        rs = randstate(nmodes)
-        rc = randchannel(nmodes)
+        repr = CanonicalForm(nmodes)
+        rs = randstate(repr)
+        rc = randchannel(repr)
         @test rc isa GaussianChannel
         @test rc * rs isa GaussianState
-        Omega = symplecticform(nmodes)
+        Omega = symplecticform(repr)
         @test all(i -> ((i >= 0) || isapprox(i, 0.0, atol = 1e-5)), real(eigvals(rs.covar .+ im*Omega)))
 
-        rspure = randstate(nmodes, pure = true)
+        rspure = randstate(repr, pure = true)
         @test all(i -> ((i >= 0) || isapprox(i, 0.0, atol = 1e-5)), real(eigvals(rspure.covar .+ im*Omega)))
         @test isapprox(purity(rspure), 1.0, atol = 1e-5)
 
-        rs_array = randstate(Array, nmodes)
-        rc_array = randchannel(Array, nmodes)
+        rs_array = randstate(Array, repr)
+        rc_array = randchannel(Array, repr)
         @test rc_array isa GaussianChannel
         @test rc_array * rs_array isa GaussianState
         @test all(i -> ((i >= 0) || isapprox(i, 0.0, atol = 1e-5)), real(eigvals(rs_array.covar .+ im*Omega)))
 
-        rspure_array = randstate(Array, nmodes, pure = true)
+        rspure_array = randstate(Array, repr, pure = true)
         @test all(i -> ((i >= 0) || isapprox(i, 0.0, atol = 1e-3)), real(eigvals(rspure_array.covar .+ im*Omega)))
         @test isapprox(purity(rspure_array), 1.0, atol = 1e-3)
 
-        rs_static = randstate(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, nmodes)
-        rc_static = randchannel(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, nmodes)
+        rs_static = randstate(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, repr)
+        rc_static = randchannel(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, repr)
         @test rc_static isa GaussianChannel
         @test rc_static * rs_static isa GaussianState
         @test all(i -> ((i >= 0) || isapprox(i, 0.0, atol = 1e-5)), real(eigvals(Array(rs_static.covar) .+ im*Omega)))
 
-        rspure_static = randstate(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, nmodes, pure = true)
+        rspure_static = randstate(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, repr, pure = true)
         @test all(i -> ((i >= 0) || isapprox(i, 0.0, atol = 1e-5)), real(eigvals(Array(rspure_static.covar) .+ im*Omega)))
         @test isapprox(purity(rspure_static), 1.0, atol = 1e-5)
     end
 
     @testset "random unitaries" begin
         nmodes = rand(1:20)
-        ru = randunitary(nmodes)
-        Omega = symplecticform(nmodes)
+        repr = CanonicalForm(nmodes)
+        ru = randunitary(repr)
+        Omega = symplecticform(repr)
         @test isapprox(ru.symplectic' * Omega * ru.symplectic, Omega, atol = 1e-5)
 
-        rupassive = randunitary(nmodes, passive = true)
+        rupassive = randunitary(repr, passive = true)
         @test isapprox(rupassive.symplectic', inv(rupassive.symplectic), atol = 1e-5)
         @test isapprox(rupassive.symplectic' * Omega * rupassive.symplectic, Omega, atol = 1e-5)
 
-        ru_array = randunitary(Array, nmodes)
+        ru_array = randunitary(Array, repr)
         @test isapprox(ru_array.symplectic' * Omega * ru_array.symplectic, Omega, atol = 1e-5)
 
-        rupassive_array = randunitary(nmodes, passive = true)
+        rupassive_array = randunitary(repr, passive = true)
         @test isapprox(rupassive_array.symplectic', inv(rupassive_array.symplectic), atol = 1e-5)
         @test isapprox(rupassive_array.symplectic' * Omega * rupassive_array.symplectic, Omega, atol = 1e-5)
 
-        ru_static = randunitary(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, nmodes)
+        ru_static = randunitary(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, repr)
         @test isapprox(ru_static.symplectic' * Omega * ru_static.symplectic, Omega, atol = 1e-5)
 
-        rupassive_static = randunitary(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, nmodes, passive = true)
+        rupassive_static = randunitary(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, repr, passive = true)
         @test isapprox(rupassive_static.symplectic', inv(rupassive_static.symplectic), atol = 1e-5)
         @test isapprox(rupassive_static.symplectic' * Omega * rupassive_static.symplectic, Omega, atol = 1e-5)
     end
 
     @testset "random channels" begin
-        nmodes = rand(1:20);
-        rc = randchannel(nmodes);
-        Omega = symplecticform(nmodes);
+        nmodes = rand(1:20)
+        repr = CanonicalForm(nmodes)
+        rc = randchannel(repr)
+        Omega = symplecticform(repr)
         @test all(i -> ((i >= 0) || isapprox(i, 0.0, atol = 1e-5)), real(eigvals(rc.noise .+ im*Omega .- im*rc.transform*Omega*rc.transform')))
 
-        rc_array = randchannel(Array, nmodes)
+        rc_array = randchannel(Array, repr)
         @test all(i -> ((i >= 0) || isapprox(i, 0.0, atol = 1e-5)), real(eigvals(rc_array.noise .+ im*Omega .- im*rc_array.transform*Omega*rc_array.transform')))
 
-        rc_static = randchannel(SVector{2*nmodes}, SMatrix{2*nmodes, 2*nmodes}, nmodes)
+        rc_static = randchannel(SVector{2*nmodes}, SMatrix{2*nmodes, 2*nmodes}, repr)
         @test all(i -> ((i >= 0) || isapprox(i, 0.0, atol = 1e-5)), real(eigvals(Array(rc_static.noise) .+ im*Omega .- im*Array(rc_static.transform)*Omega*Array(rc_static.transform)')))
     end
 end

--- a/test/test_randoms.jl
+++ b/test/test_randoms.jl
@@ -1,102 +1,102 @@
-@testitem "CanonicalForm" begin
+@testitem "Quadrature pair basis" begin
     using Gabs
     using StaticArrays
     using LinearAlgebra: eigvals, adjoint
 
     @testset "random utils" begin
         nmodes = rand(1:20)
-        repr = CanonicalForm(nmodes)
-        U = Gabs._rand_unitary(repr)
+        basis = QuadPairBasis(nmodes)
+        U = Gabs._rand_unitary(basis)
         @test isapprox(adjoint(U), inv(U), atol = 1e-5)
 
-        O = Gabs._rand_orthogonal_symplectic(repr)
+        O = Gabs._rand_orthogonal_symplectic(basis)
         @test isapprox(O', inv(O), atol = 1e-5)
-        Omega = symplecticform(repr)
+        Omega = symplecticform(basis)
         @test isapprox(O' * Omega * O, Omega, atol = 1e-5)
 
-        Spassive = randsymplectic(repr, passive = true)
+        Spassive = randsymplectic(basis, passive = true)
         @test isapprox(Spassive', inv(Spassive), atol = 1e-5)
         @test isapprox(Spassive' * Omega * Spassive, Omega, atol = 1e-5)
 
-        S = randsymplectic(repr)
+        S = randsymplectic(basis)
         @test isapprox(S' * Omega * S, Omega, atol = 1e-5)
 
-        S_array = randsymplectic(Array, repr)
+        S_array = randsymplectic(Array, basis)
         @test isapprox(S_array' * Omega * S_array, Omega, atol = 1e-5)
     end
 
     @testset "random states" begin
         nmodes = rand(1:20)
-        repr = CanonicalForm(nmodes)
-        rs = randstate(repr)
-        rc = randchannel(repr)
+        basis = QuadPairBasis(nmodes)
+        rs = randstate(basis)
+        rc = randchannel(basis)
         @test rc isa GaussianChannel
         @test rc * rs isa GaussianState
-        Omega = symplecticform(repr)
+        Omega = symplecticform(basis)
         @test all(i -> ((i >= 0) || isapprox(i, 0.0, atol = 1e-5)), real(eigvals(rs.covar .+ im*Omega)))
 
-        rspure = randstate(repr, pure = true)
+        rspure = randstate(basis, pure = true)
         @test all(i -> ((i >= 0) || isapprox(i, 0.0, atol = 1e-5)), real(eigvals(rspure.covar .+ im*Omega)))
         @test isapprox(purity(rspure), 1.0, atol = 1e-5)
 
-        rs_array = randstate(Array, repr)
-        rc_array = randchannel(Array, repr)
+        rs_array = randstate(Array, basis)
+        rc_array = randchannel(Array, basis)
         @test rc_array isa GaussianChannel
         @test rc_array * rs_array isa GaussianState
         @test all(i -> ((i >= 0) || isapprox(i, 0.0, atol = 1e-5)), real(eigvals(rs_array.covar .+ im*Omega)))
 
-        rspure_array = randstate(Array, repr, pure = true)
+        rspure_array = randstate(Array, basis, pure = true)
         @test all(i -> ((i >= 0) || isapprox(i, 0.0, atol = 1e-3)), real(eigvals(rspure_array.covar .+ im*Omega)))
         @test isapprox(purity(rspure_array), 1.0, atol = 1e-3)
 
-        rs_static = randstate(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, repr)
-        rc_static = randchannel(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, repr)
+        rs_static = randstate(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, basis)
+        rc_static = randchannel(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, basis)
         @test rc_static isa GaussianChannel
         @test rc_static * rs_static isa GaussianState
         @test all(i -> ((i >= 0) || isapprox(i, 0.0, atol = 1e-5)), real(eigvals(Array(rs_static.covar) .+ im*Omega)))
 
-        rspure_static = randstate(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, repr, pure = true)
+        rspure_static = randstate(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, basis, pure = true)
         @test all(i -> ((i >= 0) || isapprox(i, 0.0, atol = 1e-5)), real(eigvals(Array(rspure_static.covar) .+ im*Omega)))
         @test isapprox(purity(rspure_static), 1.0, atol = 1e-5)
     end
 
     @testset "random unitaries" begin
         nmodes = rand(1:20)
-        repr = CanonicalForm(nmodes)
-        ru = randunitary(repr)
-        Omega = symplecticform(repr)
+        basis = QuadPairBasis(nmodes)
+        ru = randunitary(basis)
+        Omega = symplecticform(basis)
         @test isapprox(ru.symplectic' * Omega * ru.symplectic, Omega, atol = 1e-5)
 
-        rupassive = randunitary(repr, passive = true)
+        rupassive = randunitary(basis, passive = true)
         @test isapprox(rupassive.symplectic', inv(rupassive.symplectic), atol = 1e-5)
         @test isapprox(rupassive.symplectic' * Omega * rupassive.symplectic, Omega, atol = 1e-5)
 
-        ru_array = randunitary(Array, repr)
+        ru_array = randunitary(Array, basis)
         @test isapprox(ru_array.symplectic' * Omega * ru_array.symplectic, Omega, atol = 1e-5)
 
-        rupassive_array = randunitary(repr, passive = true)
+        rupassive_array = randunitary(basis, passive = true)
         @test isapprox(rupassive_array.symplectic', inv(rupassive_array.symplectic), atol = 1e-5)
         @test isapprox(rupassive_array.symplectic' * Omega * rupassive_array.symplectic, Omega, atol = 1e-5)
 
-        ru_static = randunitary(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, repr)
+        ru_static = randunitary(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, basis)
         @test isapprox(ru_static.symplectic' * Omega * ru_static.symplectic, Omega, atol = 1e-5)
 
-        rupassive_static = randunitary(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, repr, passive = true)
+        rupassive_static = randunitary(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, basis, passive = true)
         @test isapprox(rupassive_static.symplectic', inv(rupassive_static.symplectic), atol = 1e-5)
         @test isapprox(rupassive_static.symplectic' * Omega * rupassive_static.symplectic, Omega, atol = 1e-5)
     end
 
     @testset "random channels" begin
         nmodes = rand(1:20)
-        repr = CanonicalForm(nmodes)
-        rc = randchannel(repr)
-        Omega = symplecticform(repr)
+        basis = QuadPairBasis(nmodes)
+        rc = randchannel(basis)
+        Omega = symplecticform(basis)
         @test all(i -> ((i >= 0) || isapprox(i, 0.0, atol = 1e-5)), real(eigvals(rc.noise .+ im*Omega .- im*rc.transform*Omega*rc.transform')))
 
-        rc_array = randchannel(Array, repr)
+        rc_array = randchannel(Array, basis)
         @test all(i -> ((i >= 0) || isapprox(i, 0.0, atol = 1e-5)), real(eigvals(rc_array.noise .+ im*Omega .- im*rc_array.transform*Omega*rc_array.transform')))
 
-        rc_static = randchannel(SVector{2*nmodes}, SMatrix{2*nmodes, 2*nmodes}, repr)
+        rc_static = randchannel(SVector{2*nmodes}, SMatrix{2*nmodes, 2*nmodes}, basis)
         @test all(i -> ((i >= 0) || isapprox(i, 0.0, atol = 1e-5)), real(eigvals(Array(rc_static.noise) .+ im*Omega .- im*Array(rc_static.transform)*Omega*Array(rc_static.transform)')))
     end
 end

--- a/test/test_states.jl
+++ b/test/test_states.jl
@@ -1,40 +1,40 @@
-@testitem "CanonicalForm" begin
+@testitem "Quadrature pair basis" begin
     using Gabs
     using StaticArrays
 
-    repr1 = CanonicalForm(1)
+    basis1 = QuadPairBasis(1)
 
     @testset "vacuum states" begin
-        @test vacuumstate(repr1) isa GaussianState
-        @test vacuumstate(SVector{2}, SMatrix{2,2}, repr1) isa GaussianState
+        @test vacuumstate(basis1) isa GaussianState
+        @test vacuumstate(SVector{2}, SMatrix{2,2}, basis1) isa GaussianState
     end
 
     @testset "thermal states" begin
         n = rand(Int64)
-        @test thermalstate(repr1, n) isa GaussianState
-        @test thermalstate(SVector{2}, SMatrix{2,2}, repr1, n) isa GaussianState
+        @test thermalstate(basis1, n) isa GaussianState
+        @test thermalstate(SVector{2}, SMatrix{2,2}, basis1, n) isa GaussianState
     end
 
     @testset "coherent states" begin
         alpha = rand(ComplexF64)
-        @test coherentstate(repr1, alpha) isa GaussianState
-        @test coherentstate(SVector{2}, SMatrix{2,2}, repr1, alpha) isa GaussianState
+        @test coherentstate(basis1, alpha) isa GaussianState
+        @test coherentstate(SVector{2}, SMatrix{2,2}, basis1, alpha) isa GaussianState
     end
 
     @testset "squeezed states" begin
         r, theta = rand(Float64), rand(Float64)
-        @test squeezedstate(repr1, r, theta) isa GaussianState
-        @test squeezedstate(SVector{2}, SMatrix{2,2}, repr1, r, theta) isa GaussianState
+        @test squeezedstate(basis1, r, theta) isa GaussianState
+        @test squeezedstate(SVector{2}, SMatrix{2,2}, basis1, r, theta) isa GaussianState
     end
 
     @testset "epr states" begin
         r, theta = rand(Float64), rand(Float64)
-        @test eprstate(2*repr1, r, theta) isa GaussianState
-        @test eprstate(SVector{4}, SMatrix{4,4}, 2*repr1, r, theta) isa GaussianState
+        @test eprstate(2*basis1, r, theta) isa GaussianState
+        @test eprstate(SVector{4}, SMatrix{4,4}, 2*basis1, r, theta) isa GaussianState
     end
 
     @testset "tensor products" begin
-        v = vacuumstate(repr1)
+        v = vacuumstate(basis1)
         vs = tensor(v, v)
         @test vs isa GaussianState
         @test tensor(SVector{4}, SMatrix{4,4}, v, v) isa GaussianState
@@ -42,10 +42,10 @@
         @test isapprox(vs, v ⊗ v)
 
         alpha = rand(ComplexF64)
-        c = coherentstate(repr1, alpha)
+        c = coherentstate(basis1, alpha)
         @test tensor(c, tensor(v, v)) == c ⊗ v ⊗ v
 
-        vstatic = vacuumstate(SVector{2}, SMatrix{2,2}, repr1)
+        vstatic = vacuumstate(SVector{2}, SMatrix{2,2}, basis1)
         tpstatic = vstatic ⊗ vstatic ⊗ vstatic
         @test tpstatic.mean isa SVector{6}
         @test tpstatic.covar isa SMatrix{6,6}
@@ -58,7 +58,7 @@
         alpha = rand(Float64)
         r, theta = rand(Float64), rand(Float64)
         n = rand(Int)
-        s1, s2, s3 = coherentstate(repr1, alpha), squeezedstate(repr1, r, theta), thermalstate(repr1, n)
+        s1, s2, s3 = coherentstate(basis1, alpha), squeezedstate(basis1, r, theta), thermalstate(basis1, n)
         state = s1 ⊗ s2 ⊗ s3
         @test ptrace(state, 1) == s1
         @test ptrace(state, 2) == s2
@@ -67,7 +67,7 @@
         @test ptrace(state, [1, 3]) == s1 ⊗ s3
         @test ptrace(state, [2, 3]) == s2 ⊗ s3
 
-        sstatic = coherentstate(SVector{2}, SMatrix{2,2}, repr1, alpha)
+        sstatic = coherentstate(SVector{2}, SMatrix{2,2}, basis1, alpha)
         tpstatic = sstatic ⊗ sstatic ⊗ sstatic
         @test ptrace(tpstatic, 1) == sstatic
         @test ptrace(tpstatic, [1,3]) == sstatic ⊗ sstatic

--- a/test/test_states.jl
+++ b/test/test_states.jl
@@ -1,4 +1,4 @@
-@testitem "Quadrature pair basis" begin
+@testitem "States" begin
     import Gabs: _changebasis
     using Gabs
     using StaticArrays

--- a/test/test_states.jl
+++ b/test/test_states.jl
@@ -1,38 +1,40 @@
-@testitem "States" begin
+@testitem "CanonicalForm" begin
     using Gabs
     using StaticArrays
 
+    repr1 = CanonicalForm(1)
+
     @testset "vacuum states" begin
-        @test vacuumstate() isa GaussianState
-        @test vacuumstate(SVector{2}, SMatrix{2,2}) isa GaussianState
+        @test vacuumstate(repr1) isa GaussianState
+        @test vacuumstate(SVector{2}, SMatrix{2,2}, repr1) isa GaussianState
     end
 
     @testset "thermal states" begin
         n = rand(Int64)
-        @test thermalstate(n) isa GaussianState
-        @test thermalstate(SVector{2}, SMatrix{2,2}, n) isa GaussianState
+        @test thermalstate(repr1, n) isa GaussianState
+        @test thermalstate(SVector{2}, SMatrix{2,2}, repr1, n) isa GaussianState
     end
 
     @testset "coherent states" begin
         alpha = rand(ComplexF64)
-        @test coherentstate(alpha) isa GaussianState
-        @test coherentstate(SVector{2}, SMatrix{2,2}, alpha) isa GaussianState
+        @test coherentstate(repr1, alpha) isa GaussianState
+        @test coherentstate(SVector{2}, SMatrix{2,2}, repr1, alpha) isa GaussianState
     end
 
     @testset "squeezed states" begin
         r, theta = rand(Float64), rand(Float64)
-        @test squeezedstate(r, theta) isa GaussianState
-        @test squeezedstate(SVector{2}, SMatrix{2,2}, r, theta) isa GaussianState
+        @test squeezedstate(repr1, r, theta) isa GaussianState
+        @test squeezedstate(SVector{2}, SMatrix{2,2}, repr1, r, theta) isa GaussianState
     end
 
     @testset "epr states" begin
         r, theta = rand(Float64), rand(Float64)
-        @test eprstate(r, theta) isa GaussianState
-        @test eprstate(SVector{4}, SMatrix{4,4}, r, theta) isa GaussianState
+        @test eprstate(2*repr1, r, theta) isa GaussianState
+        @test eprstate(SVector{4}, SMatrix{4,4}, 2*repr1, r, theta) isa GaussianState
     end
 
     @testset "tensor products" begin
-        v = vacuumstate()
+        v = vacuumstate(repr1)
         vs = tensor(v, v)
         @test vs isa GaussianState
         @test tensor(SVector{4}, SMatrix{4,4}, v, v) isa GaussianState
@@ -40,11 +42,10 @@
         @test isapprox(vs, v ⊗ v)
 
         alpha = rand(ComplexF64)
-        c = coherentstate(alpha)
+        c = coherentstate(repr1, alpha)
         @test tensor(c, tensor(v, v)) == c ⊗ v ⊗ v
 
-
-        vstatic = vacuumstate(SVector{2}, SMatrix{2,2})
+        vstatic = vacuumstate(SVector{2}, SMatrix{2,2}, repr1)
         tpstatic = vstatic ⊗ vstatic ⊗ vstatic
         @test tpstatic.mean isa SVector{6}
         @test tpstatic.covar isa SMatrix{6,6}
@@ -57,7 +58,7 @@
         alpha = rand(Float64)
         r, theta = rand(Float64), rand(Float64)
         n = rand(Int)
-        s1, s2, s3 = coherentstate(alpha), squeezedstate(r, theta), thermalstate(n)
+        s1, s2, s3 = coherentstate(repr1, alpha), squeezedstate(repr1, r, theta), thermalstate(repr1, n)
         state = s1 ⊗ s2 ⊗ s3
         @test ptrace(state, 1) == s1
         @test ptrace(state, 2) == s2
@@ -66,7 +67,7 @@
         @test ptrace(state, [1, 3]) == s1 ⊗ s3
         @test ptrace(state, [2, 3]) == s2 ⊗ s3
 
-        sstatic = coherentstate(SVector{2}, SMatrix{2,2}, alpha)
+        sstatic = coherentstate(SVector{2}, SMatrix{2,2}, repr1, alpha)
         tpstatic = sstatic ⊗ sstatic ⊗ sstatic
         @test ptrace(tpstatic, 1) == sstatic
         @test ptrace(tpstatic, [1,3]) == sstatic ⊗ sstatic

--- a/test/test_states.jl
+++ b/test/test_states.jl
@@ -95,7 +95,7 @@
         @test ptrace(state_qpair, [1, 3]) == s1_qpair ⊗ s3_qpair
         @test ptrace(state_qpair, [2, 3]) == s2_qpair ⊗ s3_qpair
 
-        s1_qblock, s2_qblock, s3_qblock = coherentstate(qpairbasis1, alpha), squeezedstate(qpairbasis1, r, theta), thermalstate(qpairbasis1, n)
+        s1_qblock, s2_qblock, s3_qblock = coherentstate(qblockbasis1, alpha), squeezedstate(qblockbasis1, r, theta), thermalstate(qblockbasis1, n)
         state_qblock = s1_qblock ⊗ s2_qblock ⊗ s3_qblock
         @test ptrace(state_qblock, 1) == s1_qblock
         @test ptrace(state_qblock, 2) == s2_qblock

--- a/test/test_states.jl
+++ b/test/test_states.jl
@@ -1,64 +1,78 @@
 @testitem "Quadrature pair basis" begin
+    import Gabs: _changebasis
     using Gabs
     using StaticArrays
 
-    basis1 = QuadPairBasis(1)
+    nmodes = rand(1:5)
+    qpairbasis = QuadPairBasis(nmodes)
+    qblockbasis = QuadBlockBasis(nmodes)
 
     @testset "vacuum states" begin
-        @test vacuumstate(basis1) isa GaussianState
-        @test vacuumstate(SVector{2}, SMatrix{2,2}, basis1) isa GaussianState
+        state = vacuumstate(qpairbasis)
+        @test state isa GaussianState
+        @test vacuumstate(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis) isa GaussianState
+        @test vacuumstate(qblockbasis) == _changebasis(state, QuadBlockBasis)
     end
 
     @testset "thermal states" begin
         n = rand(Int64)
-        @test thermalstate(basis1, n) isa GaussianState
-        @test thermalstate(SVector{2}, SMatrix{2,2}, basis1, n) isa GaussianState
+        state = thermalstate(qpairbasis, n)
+        @test state isa GaussianState
+        @test thermalstate(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis, n) isa GaussianState
+        @test thermalstate(qblockbasis, n) == _changebasis(state, QuadBlockBasis)
     end
 
     @testset "coherent states" begin
         alpha = rand(ComplexF64)
-        @test coherentstate(basis1, alpha) isa GaussianState
-        @test coherentstate(SVector{2}, SMatrix{2,2}, basis1, alpha) isa GaussianState
+        state = coherentstate(qpairbasis, alpha)
+        @test state isa GaussianState
+        @test coherentstate(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis, alpha) isa GaussianState
+        @test coherentstate(qblockbasis, alpha) == _changebasis(state, QuadBlockBasis)
     end
 
     @testset "squeezed states" begin
         r, theta = rand(Float64), rand(Float64)
-        @test squeezedstate(basis1, r, theta) isa GaussianState
-        @test squeezedstate(SVector{2}, SMatrix{2,2}, basis1, r, theta) isa GaussianState
+        state = squeezedstate(qpairbasis, r, theta)
+        @test state isa GaussianState
+        @test squeezedstate(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis, r, theta) isa GaussianState
+        @test squeezedstate(qblockbasis, r, theta) == _changebasis(state, QuadBlockBasis)
     end
 
     @testset "epr states" begin
         r, theta = rand(Float64), rand(Float64)
-        @test eprstate(2*basis1, r, theta) isa GaussianState
-        @test eprstate(SVector{4}, SMatrix{4,4}, 2*basis1, r, theta) isa GaussianState
+        state = eprstate(2*qpairbasis, r, theta)
+        @test state isa GaussianState
+        @test eprstate(SVector{4*nmodes}, SMatrix{4*nmodes,4*nmodes}, 2*qpairbasis, r, theta) isa GaussianState
+        @test eprstate(2*qblockbasis, r, theta) == _changebasis(state, QuadBlockBasis)
     end
 
     @testset "tensor products" begin
-        v = vacuumstate(basis1)
+        v = vacuumstate(qpairbasis)
         vs = tensor(v, v)
         @test vs isa GaussianState
-        @test tensor(SVector{4}, SMatrix{4,4}, v, v) isa GaussianState
+        @test tensor(SVector{4*nmodes}, SMatrix{4*nmodes,4*nmodes}, v, v) isa GaussianState
         @test vs == v ⊗ v
         @test isapprox(vs, v ⊗ v)
 
         alpha = rand(ComplexF64)
-        c = coherentstate(basis1, alpha)
+        c = coherentstate(qpairbasis, alpha)
         @test tensor(c, tensor(v, v)) == c ⊗ v ⊗ v
 
-        vstatic = vacuumstate(SVector{2}, SMatrix{2,2}, basis1)
+        vstatic = vacuumstate(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis)
         tpstatic = vstatic ⊗ vstatic ⊗ vstatic
-        @test tpstatic.mean isa SVector{6}
-        @test tpstatic.covar isa SMatrix{6,6}
+        @test tpstatic.mean isa SVector{6*nmodes}
+        @test tpstatic.covar isa SMatrix{6*nmodes,6*nmodes}
         tp = vstatic ⊗ v ⊗ vstatic
         @test tp.mean isa Vector
         @test tp.covar isa Matrix
     end
 
     @testset "partial trace" begin
+        qpairbasis1 = QuadPairBasis(1)
         alpha = rand(Float64)
         r, theta = rand(Float64), rand(Float64)
         n = rand(Int)
-        s1, s2, s3 = coherentstate(basis1, alpha), squeezedstate(basis1, r, theta), thermalstate(basis1, n)
+        s1, s2, s3 = coherentstate(qpairbasis1, alpha), squeezedstate(qpairbasis1, r, theta), thermalstate(qpairbasis1, n)
         state = s1 ⊗ s2 ⊗ s3
         @test ptrace(state, 1) == s1
         @test ptrace(state, 2) == s2
@@ -67,7 +81,7 @@
         @test ptrace(state, [1, 3]) == s1 ⊗ s3
         @test ptrace(state, [2, 3]) == s2 ⊗ s3
 
-        sstatic = coherentstate(SVector{2}, SMatrix{2,2}, basis1, alpha)
+        sstatic = coherentstate(SVector{2}, SMatrix{2,2}, qpairbasis1, alpha)
         tpstatic = sstatic ⊗ sstatic ⊗ sstatic
         @test ptrace(tpstatic, 1) == sstatic
         @test ptrace(tpstatic, [1,3]) == sstatic ⊗ sstatic

--- a/test/test_states.jl
+++ b/test/test_states.jl
@@ -16,34 +16,42 @@
 
     @testset "thermal states" begin
         n = rand(Int64)
+        ns = rand(Int64, nmodes)
         state = thermalstate(qpairbasis, n)
         @test state isa GaussianState
         @test thermalstate(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis, n) isa GaussianState
         @test thermalstate(qblockbasis, n) == _changebasis(state, QuadBlockBasis)
+        @test thermalstate(qblockbasis, ns) == _changebasis(thermalstate(qpairbasis, ns), QuadBlockBasis)
     end
 
     @testset "coherent states" begin
         alpha = rand(ComplexF64)
+        alphas = rand(ComplexF64, nmodes)
         state = coherentstate(qpairbasis, alpha)
         @test state isa GaussianState
         @test coherentstate(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis, alpha) isa GaussianState
         @test coherentstate(qblockbasis, alpha) == _changebasis(state, QuadBlockBasis)
+        @test coherentstate(qblockbasis, alphas) == _changebasis(coherentstate(qpairbasis, alphas), QuadBlockBasis)
     end
 
     @testset "squeezed states" begin
         r, theta = rand(Float64), rand(Float64)
+        rs, thetas = rand(Float64, nmodes), rand(Float64, nmodes)
         state = squeezedstate(qpairbasis, r, theta)
         @test state isa GaussianState
         @test squeezedstate(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis, r, theta) isa GaussianState
         @test squeezedstate(qblockbasis, r, theta) == _changebasis(state, QuadBlockBasis)
+        @test squeezedstate(qblockbasis, rs, thetas) == _changebasis(squeezedstate(qpairbasis, rs, thetas), QuadBlockBasis)
     end
 
     @testset "epr states" begin
         r, theta = rand(Float64), rand(Float64)
+        rs, thetas = rand(Float64, nmodes), rand(Float64, nmodes)
         state = eprstate(2*qpairbasis, r, theta)
         @test state isa GaussianState
         @test eprstate(SVector{4*nmodes}, SMatrix{4*nmodes,4*nmodes}, 2*qpairbasis, r, theta) isa GaussianState
         @test eprstate(2*qblockbasis, r, theta) == _changebasis(state, QuadBlockBasis)
+        @test eprstate(2*qblockbasis, rs, thetas) == _changebasis(eprstate(2*qpairbasis, rs, thetas), QuadBlockBasis)
     end
 
     @testset "tensor products" begin

--- a/test/test_states.jl
+++ b/test/test_states.jl
@@ -66,6 +66,11 @@
         c = coherentstate(qpairbasis, alpha)
         @test tensor(c, tensor(v, v)) == c ⊗ v ⊗ v
 
+        r, theta = rand(Float64), rand(Float64)
+        sq = squeezedstate(qblockbasis, r, theta)
+        sqs = squeezedstate(2*qblockbasis, repeat([r], 2*nmodes), repeat([theta], 2*nmodes))
+        @test sq ⊗ sq == sqs
+
         vstatic = vacuumstate(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis)
         tpstatic = vstatic ⊗ vstatic ⊗ vstatic
         @test tpstatic.mean isa SVector{6*nmodes}
@@ -77,24 +82,34 @@
 
     @testset "partial trace" begin
         qpairbasis1 = QuadPairBasis(1)
+        qblockbasis1 = QuadBlockBasis(1)
         alpha = rand(Float64)
         r, theta = rand(Float64), rand(Float64)
         n = rand(Int)
-        s1, s2, s3 = coherentstate(qpairbasis1, alpha), squeezedstate(qpairbasis1, r, theta), thermalstate(qpairbasis1, n)
-        state = s1 ⊗ s2 ⊗ s3
-        @test ptrace(state, 1) == s1
-        @test ptrace(state, 2) == s2
-        @test ptrace(state, 3) == s3
-        @test ptrace(state, [1, 2]) == s1 ⊗ s2
-        @test ptrace(state, [1, 3]) == s1 ⊗ s3
-        @test ptrace(state, [2, 3]) == s2 ⊗ s3
+        s1_qpair, s2_qpair, s3_qpair = coherentstate(qpairbasis1, alpha), squeezedstate(qpairbasis1, r, theta), thermalstate(qpairbasis1, n)
+        state_qpair = s1_qpair ⊗ s2_qpair ⊗ s3_qpair
+        @test ptrace(state_qpair, 1) == s1_qpair
+        @test ptrace(state_qpair, 2) == s2_qpair
+        @test ptrace(state_qpair, 3) == s3_qpair
+        @test ptrace(state_qpair, [1, 2]) == s1_qpair ⊗ s2_qpair
+        @test ptrace(state_qpair, [1, 3]) == s1_qpair ⊗ s3_qpair
+        @test ptrace(state_qpair, [2, 3]) == s2_qpair ⊗ s3_qpair
+
+        s1_qblock, s2_qblock, s3_qblock = coherentstate(qpairbasis1, alpha), squeezedstate(qpairbasis1, r, theta), thermalstate(qpairbasis1, n)
+        state_qblock = s1_qblock ⊗ s2_qblock ⊗ s3_qblock
+        @test ptrace(state_qblock, 1) == s1_qblock
+        @test ptrace(state_qblock, 2) == s2_qblock
+        @test ptrace(state_qblock, 3) == s3_qblock
+        @test ptrace(state_qblock, [1, 2]) == s1_qblock ⊗ s2_qblock
+        @test ptrace(state_qblock, [1, 3]) == s1_qblock ⊗ s3_qblock
+        @test ptrace(state_qblock, [2, 3]) == s2_qblock ⊗ s3_qblock
 
         sstatic = coherentstate(SVector{2}, SMatrix{2,2}, qpairbasis1, alpha)
         tpstatic = sstatic ⊗ sstatic ⊗ sstatic
         @test ptrace(tpstatic, 1) == sstatic
         @test ptrace(tpstatic, [1,3]) == sstatic ⊗ sstatic
 
-        @test ptrace(SVector{2}, SMatrix{2,2}, state, 1) isa GaussianState
-        @test ptrace(SVector{4}, SMatrix{4,4}, state, [1, 3]) isa GaussianState
+        @test ptrace(SVector{2}, SMatrix{2,2}, state_qpair, 1) isa GaussianState
+        @test ptrace(SVector{4}, SMatrix{4,4}, state_qpair, [1, 3]) isa GaussianState
     end
 end

--- a/test/test_throws.jl
+++ b/test/test_throws.jl
@@ -2,25 +2,25 @@
     using Gabs
     using CairoMakie
 
-    repr1 = CanonicalForm(1)
+    basis1 = QuadPairBasis(1)
     @testset "type throws" begin
-        @test_throws DimensionMismatch GaussianState(repr1, [1.0, 2.0, 3.0], [3.0 4.0; 5.0 6.0])
-        @test_throws DimensionMismatch GaussianChannel(repr1, [1.0, 2.0, 3.0], [3.0 4.0; 5.0 6.0], [3.0 4.0; 5.0 6.0])
-        @test_throws DimensionMismatch GaussianChannel(repr1, [1.0, 2.0], [3.0 4.0; 5.0 6.0], [3.0 4.0 4.0; 5.0 6.0 4.0])
-        vac = vacuumstate(repr1)
+        @test_throws DimensionMismatch GaussianState(basis1, [1.0, 2.0, 3.0], [3.0 4.0; 5.0 6.0])
+        @test_throws DimensionMismatch GaussianChannel(basis1, [1.0, 2.0, 3.0], [3.0 4.0; 5.0 6.0], [3.0 4.0; 5.0 6.0])
+        @test_throws DimensionMismatch GaussianChannel(basis1, [1.0, 2.0], [3.0 4.0; 5.0 6.0], [3.0 4.0 4.0; 5.0 6.0 4.0])
+        vac = vacuumstate(basis1)
         vacs = vac ⊗ vac ⊗ vac ⊗ vac
         @test_throws DimensionMismatch Generaldyne(vacs, vac ⊗ vac, [2, 4, 5])
     end
 
     @testset "action throws" begin
-        v = vacuumstate(repr1)
-        ts = twosqueeze(2*repr1, rand(), rand())
+        v = vacuumstate(basis1)
+        ts = twosqueeze(2*basis1, rand(), rand())
         @test_throws DimensionMismatch ts * v
         @test_throws DimensionMismatch apply!(v, ts)
     end
 
     @testset "plot extension throws" begin
-        ts = twosqueeze(2*repr1, rand(), rand())
+        ts = twosqueeze(2*basis1, rand(), rand())
         @test_throws ArgumentError Makie.heatmap(collect(-3.0:0.25:3.0), collect(-3.0:0.25:3.0), ts)
     end
 end

--- a/test/test_throws.jl
+++ b/test/test_throws.jl
@@ -2,24 +2,25 @@
     using Gabs
     using CairoMakie
 
+    repr1 = CanonicalForm(1)
     @testset "type throws" begin
-        @test_throws DimensionMismatch GaussianState([1.0, 2.0, 3.0], [3.0 4.0; 5.0 6.0], 1)
-        @test_throws DimensionMismatch GaussianChannel([1.0, 2.0, 3.0], [3.0 4.0; 5.0 6.0], [3.0 4.0; 5.0 6.0], 1)
-        @test_throws DimensionMismatch GaussianChannel([1.0, 2.0], [3.0 4.0; 5.0 6.0], [3.0 4.0 4.0; 5.0 6.0 4.0], 1)
-        vac = vacuumstate()
+        @test_throws DimensionMismatch GaussianState(repr1, [1.0, 2.0, 3.0], [3.0 4.0; 5.0 6.0])
+        @test_throws DimensionMismatch GaussianChannel(repr1, [1.0, 2.0, 3.0], [3.0 4.0; 5.0 6.0], [3.0 4.0; 5.0 6.0])
+        @test_throws DimensionMismatch GaussianChannel(repr1, [1.0, 2.0], [3.0 4.0; 5.0 6.0], [3.0 4.0 4.0; 5.0 6.0 4.0])
+        vac = vacuumstate(repr1)
         vacs = vac ⊗ vac ⊗ vac ⊗ vac
         @test_throws DimensionMismatch Generaldyne(vacs, vac ⊗ vac, [2, 4, 5])
     end
 
     @testset "action throws" begin
-        v = vacuumstate()
-        ts = twosqueeze(rand(), rand())
+        v = vacuumstate(repr1)
+        ts = twosqueeze(2*repr1, rand(), rand())
         @test_throws DimensionMismatch ts * v
         @test_throws DimensionMismatch apply!(v, ts)
     end
 
     @testset "plot extension throws" begin
-        ts = twosqueeze(rand(), rand())
+        ts = twosqueeze(2*repr1, rand(), rand())
         @test_throws ArgumentError Makie.heatmap(collect(-3.0:0.25:3.0), collect(-3.0:0.25:3.0), ts)
     end
 end

--- a/test/test_unitaries.jl
+++ b/test/test_unitaries.jl
@@ -1,61 +1,74 @@
 @testitem "Quadrature pair basis" begin
+    import Gabs: _changebasis
     using Gabs
     using StaticArrays
     
-    basis1 = QuadPairBasis(1)
+    nmodes = rand(1:5)
+    qpairbasis = QuadPairBasis(nmodes)
+    qblockbasis = QuadBlockBasis(nmodes)
 
     @testset "displacement operator" begin
         alpha = rand(ComplexF64)
-        @test displace(basis1, alpha) isa GaussianUnitary
-        @test displace(Array, basis1, alpha) isa GaussianUnitary
-        @test displace(SVector{2}, SMatrix{2,2}, basis1, alpha) isa GaussianUnitary
+        op = displace(qpairbasis, alpha)
+        @test op isa GaussianUnitary
+        @test displace(Array, qpairbasis, alpha) isa GaussianUnitary
+        @test displace(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis, alpha) isa GaussianUnitary
+        @test displace(qblockbasis, alpha) == _changebasis(op, QuadBlockBasis)
     end
 
     @testset "squeeze operator" begin
         r, theta = rand(Float64), rand(Float64)
-        @test squeeze(basis1, r, theta) isa GaussianUnitary
-        @test squeeze(Array, basis1, r, theta) isa GaussianUnitary
-        @test squeeze(SVector{2}, SMatrix{2,2}, basis1, r, theta) isa GaussianUnitary
+        op = squeeze(qpairbasis, r, theta)
+        @test op isa GaussianUnitary
+        @test squeeze(Array, qpairbasis, r, theta) isa GaussianUnitary
+        @test squeeze(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis, r, theta) isa GaussianUnitary
+        @test squeeze(qblockbasis, r, theta) == _changebasis(op, QuadBlockBasis)
     end
 
     @testset "two-mode squeeze operator" begin
         r, theta = rand(Float64), rand(Float64)
-        @test twosqueeze(2*basis1, r, theta) isa GaussianUnitary
-        @test twosqueeze(Array, 2*basis1, r, theta) isa GaussianUnitary
-        @test twosqueeze(SVector{4}, SMatrix{4,4}, 2*basis1, r, theta) isa GaussianUnitary
+        op = twosqueeze(2*qpairbasis, r, theta)
+        @test op isa GaussianUnitary
+        @test twosqueeze(Array, 2*qpairbasis, r, theta) isa GaussianUnitary
+        @test twosqueeze(SVector{4*nmodes}, SMatrix{4*nmodes,4*nmodes}, 2*qpairbasis, r, theta) isa GaussianUnitary
+        @test twosqueeze(2*qblockbasis, r, theta) == _changebasis(op, QuadBlockBasis)
     end
 
     @testset "phase-shift operator" begin
         theta = rand(Float64)
-        @test phaseshift(basis1, theta) isa GaussianUnitary
-        @test phaseshift(Array, basis1, theta) isa GaussianUnitary
-        @test phaseshift(SVector{2}, SMatrix{2,2}, basis1, theta) isa GaussianUnitary
+        op = phaseshift(qpairbasis, theta)
+        @test op isa GaussianUnitary
+        @test phaseshift(Array, qpairbasis, theta) isa GaussianUnitary
+        @test phaseshift(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis, theta) isa GaussianUnitary
+        @test phaseshift(qblockbasis, theta) == _changebasis(op, QuadBlockBasis)
     end
 
     @testset "beamsplitter operator" begin
         theta = rand(Float64)
-        @test beamsplitter(2*basis1, theta) isa GaussianUnitary
-        @test beamsplitter(Array, 2*basis1, theta) isa GaussianUnitary
-        @test beamsplitter(SVector{4}, SMatrix{4,4}, 2*basis1, theta) isa GaussianUnitary
+        op = beamsplitter(2*qpairbasis, theta)
+        @test op isa GaussianUnitary
+        @test beamsplitter(Array, 2*qpairbasis, theta) isa GaussianUnitary
+        @test beamsplitter(SVector{4*nmodes}, SMatrix{4*nmodes,4*nmodes}, 2*qpairbasis, theta) isa GaussianUnitary
+        @test beamsplitter(2*qblockbasis, theta) == _changebasis(op, QuadBlockBasis)
     end
 
     @testset "tensor products" begin
         alpha1, alpha2 = rand(ComplexF64), rand(ComplexF64)
-        d1, d2 = displace(basis1, alpha1), displace(basis1, alpha2)
+        d1, d2 = displace(qpairbasis, alpha1), displace(qpairbasis, alpha2)
         ds = tensor(d1, d2)
         @test ds isa GaussianUnitary
         @test ds == d1 ⊗ d2
         @test isapprox(ds, d1 ⊗ d2)
-        @test tensor(SVector{4}, SMatrix{4,4}, d1, d2) isa GaussianUnitary
+        @test tensor(SVector{4*nmodes}, SMatrix{4*nmodes,4*nmodes}, d1, d2) isa GaussianUnitary
 
         r, theta = rand(Float64), rand(Float64)
-        p = phaseshift(basis1, theta)
+        p = phaseshift(qpairbasis, theta)
         @test tensor(p, tensor(d1, d2)) == p ⊗ d1 ⊗ d2
 
-        dstatic = displace(SVector{2}, SMatrix{2,2}, basis1, alpha1)
+        dstatic = displace(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis, alpha1)
         tpstatic = dstatic ⊗ dstatic ⊗ dstatic
-        @test tpstatic.disp isa SVector{6}
-        @test tpstatic.symplectic isa SMatrix{6,6}
+        @test tpstatic.disp isa SVector{6*nmodes}
+        @test tpstatic.symplectic isa SMatrix{6*nmodes,6*nmodes}
         tp = dstatic ⊗ d1 ⊗ dstatic
         @test tp.disp isa Vector
         @test tp.symplectic isa Matrix
@@ -63,16 +76,16 @@
 
     @testset "actions" begin
         alpha = rand(ComplexF64)
-        d = displace(basis1, alpha)
-        v = vacuumstate(basis1)
-        c = coherentstate(basis1, alpha)
+        d = displace(qpairbasis, alpha)
+        v = vacuumstate(qpairbasis)
+        c = coherentstate(qpairbasis, alpha)
         @test d * v == c
         @test apply!(v, d) == c
         
-        v1, v2 = vacuumstate(basis1), vacuumstate(basis1)
+        v1, v2 = vacuumstate(qpairbasis), vacuumstate(qpairbasis)
         alpha1, alpha2 = rand(ComplexF64), rand(ComplexF64)
-        d1, d2 = displace(basis1, alpha1), displace(basis1, alpha2)
-        c1, c2 = coherentstate(basis1, alpha1), coherentstate(basis1, alpha2)
+        d1, d2 = displace(qpairbasis, alpha1), displace(qpairbasis, alpha2)
+        c1, c2 = coherentstate(qpairbasis, alpha1), coherentstate(qpairbasis, alpha2)
         @test (d1 ⊗ d2) * (v1 ⊗ v2) == c1 ⊗ c2
     end
 end

--- a/test/test_unitaries.jl
+++ b/test/test_unitaries.jl
@@ -1,40 +1,47 @@
-@testitem "Unitaries" begin
+@testitem "CanonicalForm" begin
     using Gabs
     using StaticArrays
     
+    repr1 = CanonicalForm(1)
+
     @testset "displacement operator" begin
         alpha = rand(ComplexF64)
-        @test displace(alpha) isa GaussianUnitary
-        @test displace(SVector{2}, SMatrix{2,2}, alpha) isa GaussianUnitary
+        @test displace(repr1, alpha) isa GaussianUnitary
+        @test displace(Array, repr1, alpha) isa GaussianUnitary
+        @test displace(SVector{2}, SMatrix{2,2}, repr1, alpha) isa GaussianUnitary
     end
 
     @testset "squeeze operator" begin
         r, theta = rand(Float64), rand(Float64)
-        @test squeeze(r, theta) isa GaussianUnitary
-        @test squeeze(SVector{2}, SMatrix{2,2}, r, theta) isa GaussianUnitary
+        @test squeeze(repr1, r, theta) isa GaussianUnitary
+        @test squeeze(Array, repr1, r, theta) isa GaussianUnitary
+        @test squeeze(SVector{2}, SMatrix{2,2}, repr1, r, theta) isa GaussianUnitary
     end
 
     @testset "two-mode squeeze operator" begin
         r, theta = rand(Float64), rand(Float64)
-        @test twosqueeze(r, theta) isa GaussianUnitary
-        @test twosqueeze(SVector{4}, SMatrix{4,4}, r, theta) isa GaussianUnitary
+        @test twosqueeze(2*repr1, r, theta) isa GaussianUnitary
+        @test twosqueeze(Array, 2*repr1, r, theta) isa GaussianUnitary
+        @test twosqueeze(SVector{4}, SMatrix{4,4}, 2*repr1, r, theta) isa GaussianUnitary
     end
 
     @testset "phase-shift operator" begin
         theta = rand(Float64)
-        @test phaseshift(theta) isa GaussianUnitary
-        @test phaseshift(SVector{2}, SMatrix{2,2}, theta) isa GaussianUnitary
+        @test phaseshift(repr1, theta) isa GaussianUnitary
+        @test phaseshift(Array, repr1, theta) isa GaussianUnitary
+        @test phaseshift(SVector{2}, SMatrix{2,2}, repr1, theta) isa GaussianUnitary
     end
 
     @testset "beamsplitter operator" begin
         theta = rand(Float64)
-        @test beamsplitter(theta) isa GaussianUnitary
-        @test beamsplitter(SVector{4}, SMatrix{4,4}, theta) isa GaussianUnitary
+        @test beamsplitter(2*repr1, theta) isa GaussianUnitary
+        @test beamsplitter(Array, 2*repr1, theta) isa GaussianUnitary
+        @test beamsplitter(SVector{4}, SMatrix{4,4}, 2*repr1, theta) isa GaussianUnitary
     end
 
     @testset "tensor products" begin
         alpha1, alpha2 = rand(ComplexF64), rand(ComplexF64)
-        d1, d2 = displace(alpha1), displace(alpha2)
+        d1, d2 = displace(repr1, alpha1), displace(repr1, alpha2)
         ds = tensor(d1, d2)
         @test ds isa GaussianUnitary
         @test ds == d1 ⊗ d2
@@ -42,10 +49,10 @@
         @test tensor(SVector{4}, SMatrix{4,4}, d1, d2) isa GaussianUnitary
 
         r, theta = rand(Float64), rand(Float64)
-        p = phaseshift(theta)
+        p = phaseshift(repr1, theta)
         @test tensor(p, tensor(d1, d2)) == p ⊗ d1 ⊗ d2
 
-        dstatic = displace(SVector{2}, SMatrix{2,2}, alpha1)
+        dstatic = displace(SVector{2}, SMatrix{2,2}, repr1, alpha1)
         tpstatic = dstatic ⊗ dstatic ⊗ dstatic
         @test tpstatic.disp isa SVector{6}
         @test tpstatic.symplectic isa SMatrix{6,6}
@@ -56,16 +63,16 @@
 
     @testset "actions" begin
         alpha = rand(ComplexF64)
-        d = displace(alpha)
-        v = vacuumstate()
-        c = coherentstate(alpha)
+        d = displace(repr1, alpha)
+        v = vacuumstate(repr1)
+        c = coherentstate(repr1, alpha)
         @test d * v == c
         @test apply!(v, d) == c
         
-        v1, v2 = vacuumstate(), vacuumstate()
+        v1, v2 = vacuumstate(repr1), vacuumstate(repr1)
         alpha1, alpha2 = rand(ComplexF64), rand(ComplexF64)
-        d1, d2 = displace(alpha1), displace(alpha2)
-        c1, c2 = coherentstate(alpha1), coherentstate(alpha2)
+        d1, d2 = displace(repr1, alpha1), displace(repr1, alpha2)
+        c1, c2 = coherentstate(repr1, alpha1), coherentstate(repr1, alpha2)
         @test (d1 ⊗ d2) * (v1 ⊗ v2) == c1 ⊗ c2
     end
 end

--- a/test/test_unitaries.jl
+++ b/test/test_unitaries.jl
@@ -1,4 +1,4 @@
-@testitem "Quadrature pair basis" begin
+@testitem "Unitaries" begin
     import Gabs: _changebasis
     using Gabs
     using StaticArrays
@@ -9,47 +9,57 @@
 
     @testset "displacement operator" begin
         alpha = rand(ComplexF64)
+        alphas = rand(ComplexF64, nmodes)
         op = displace(qpairbasis, alpha)
         @test op isa GaussianUnitary
         @test displace(Array, qpairbasis, alpha) isa GaussianUnitary
         @test displace(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis, alpha) isa GaussianUnitary
         @test displace(qblockbasis, alpha) == _changebasis(op, QuadBlockBasis)
+        @test displace(qblockbasis, alphas) == _changebasis(displace(qpairbasis, alphas), QuadBlockBasis)
     end
 
     @testset "squeeze operator" begin
         r, theta = rand(Float64), rand(Float64)
+        rs, thetas = rand(Float64, nmodes), rand(Float64, nmodes)
         op = squeeze(qpairbasis, r, theta)
         @test op isa GaussianUnitary
         @test squeeze(Array, qpairbasis, r, theta) isa GaussianUnitary
         @test squeeze(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis, r, theta) isa GaussianUnitary
         @test squeeze(qblockbasis, r, theta) == _changebasis(op, QuadBlockBasis)
+        @test squeeze(qblockbasis, rs, thetas) == _changebasis(squeeze(qpairbasis, rs, thetas), QuadBlockBasis)
     end
 
     @testset "two-mode squeeze operator" begin
         r, theta = rand(Float64), rand(Float64)
+        rs, thetas = rand(Float64, nmodes), rand(Float64, nmodes)
         op = twosqueeze(2*qpairbasis, r, theta)
         @test op isa GaussianUnitary
         @test twosqueeze(Array, 2*qpairbasis, r, theta) isa GaussianUnitary
         @test twosqueeze(SVector{4*nmodes}, SMatrix{4*nmodes,4*nmodes}, 2*qpairbasis, r, theta) isa GaussianUnitary
         @test twosqueeze(2*qblockbasis, r, theta) == _changebasis(op, QuadBlockBasis)
+        @test twosqueeze(2*qblockbasis, rs, thetas) == _changebasis(twosqueeze(2*qpairbasis, rs, thetas), QuadBlockBasis)
     end
 
     @testset "phase-shift operator" begin
         theta = rand(Float64)
+        thetas = rand(Float64, nmodes)
         op = phaseshift(qpairbasis, theta)
         @test op isa GaussianUnitary
         @test phaseshift(Array, qpairbasis, theta) isa GaussianUnitary
         @test phaseshift(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis, theta) isa GaussianUnitary
         @test phaseshift(qblockbasis, theta) == _changebasis(op, QuadBlockBasis)
+        @test phaseshift(qblockbasis, thetas) == _changebasis(phaseshift(qpairbasis, thetas), QuadBlockBasis)
     end
 
     @testset "beamsplitter operator" begin
         theta = rand(Float64)
+        thetas = rand(Float64, nmodes)
         op = beamsplitter(2*qpairbasis, theta)
         @test op isa GaussianUnitary
         @test beamsplitter(Array, 2*qpairbasis, theta) isa GaussianUnitary
         @test beamsplitter(SVector{4*nmodes}, SMatrix{4*nmodes,4*nmodes}, 2*qpairbasis, theta) isa GaussianUnitary
         @test beamsplitter(2*qblockbasis, theta) == _changebasis(op, QuadBlockBasis)
+        @test beamsplitter(2*qblockbasis, thetas) == _changebasis(beamsplitter(2*qpairbasis, thetas), QuadBlockBasis)
     end
 
     @testset "tensor products" begin

--- a/test/test_unitaries.jl
+++ b/test/test_unitaries.jl
@@ -1,47 +1,47 @@
-@testitem "CanonicalForm" begin
+@testitem "Quadrature pair basis" begin
     using Gabs
     using StaticArrays
     
-    repr1 = CanonicalForm(1)
+    basis1 = QuadPairBasis(1)
 
     @testset "displacement operator" begin
         alpha = rand(ComplexF64)
-        @test displace(repr1, alpha) isa GaussianUnitary
-        @test displace(Array, repr1, alpha) isa GaussianUnitary
-        @test displace(SVector{2}, SMatrix{2,2}, repr1, alpha) isa GaussianUnitary
+        @test displace(basis1, alpha) isa GaussianUnitary
+        @test displace(Array, basis1, alpha) isa GaussianUnitary
+        @test displace(SVector{2}, SMatrix{2,2}, basis1, alpha) isa GaussianUnitary
     end
 
     @testset "squeeze operator" begin
         r, theta = rand(Float64), rand(Float64)
-        @test squeeze(repr1, r, theta) isa GaussianUnitary
-        @test squeeze(Array, repr1, r, theta) isa GaussianUnitary
-        @test squeeze(SVector{2}, SMatrix{2,2}, repr1, r, theta) isa GaussianUnitary
+        @test squeeze(basis1, r, theta) isa GaussianUnitary
+        @test squeeze(Array, basis1, r, theta) isa GaussianUnitary
+        @test squeeze(SVector{2}, SMatrix{2,2}, basis1, r, theta) isa GaussianUnitary
     end
 
     @testset "two-mode squeeze operator" begin
         r, theta = rand(Float64), rand(Float64)
-        @test twosqueeze(2*repr1, r, theta) isa GaussianUnitary
-        @test twosqueeze(Array, 2*repr1, r, theta) isa GaussianUnitary
-        @test twosqueeze(SVector{4}, SMatrix{4,4}, 2*repr1, r, theta) isa GaussianUnitary
+        @test twosqueeze(2*basis1, r, theta) isa GaussianUnitary
+        @test twosqueeze(Array, 2*basis1, r, theta) isa GaussianUnitary
+        @test twosqueeze(SVector{4}, SMatrix{4,4}, 2*basis1, r, theta) isa GaussianUnitary
     end
 
     @testset "phase-shift operator" begin
         theta = rand(Float64)
-        @test phaseshift(repr1, theta) isa GaussianUnitary
-        @test phaseshift(Array, repr1, theta) isa GaussianUnitary
-        @test phaseshift(SVector{2}, SMatrix{2,2}, repr1, theta) isa GaussianUnitary
+        @test phaseshift(basis1, theta) isa GaussianUnitary
+        @test phaseshift(Array, basis1, theta) isa GaussianUnitary
+        @test phaseshift(SVector{2}, SMatrix{2,2}, basis1, theta) isa GaussianUnitary
     end
 
     @testset "beamsplitter operator" begin
         theta = rand(Float64)
-        @test beamsplitter(2*repr1, theta) isa GaussianUnitary
-        @test beamsplitter(Array, 2*repr1, theta) isa GaussianUnitary
-        @test beamsplitter(SVector{4}, SMatrix{4,4}, 2*repr1, theta) isa GaussianUnitary
+        @test beamsplitter(2*basis1, theta) isa GaussianUnitary
+        @test beamsplitter(Array, 2*basis1, theta) isa GaussianUnitary
+        @test beamsplitter(SVector{4}, SMatrix{4,4}, 2*basis1, theta) isa GaussianUnitary
     end
 
     @testset "tensor products" begin
         alpha1, alpha2 = rand(ComplexF64), rand(ComplexF64)
-        d1, d2 = displace(repr1, alpha1), displace(repr1, alpha2)
+        d1, d2 = displace(basis1, alpha1), displace(basis1, alpha2)
         ds = tensor(d1, d2)
         @test ds isa GaussianUnitary
         @test ds == d1 ⊗ d2
@@ -49,10 +49,10 @@
         @test tensor(SVector{4}, SMatrix{4,4}, d1, d2) isa GaussianUnitary
 
         r, theta = rand(Float64), rand(Float64)
-        p = phaseshift(repr1, theta)
+        p = phaseshift(basis1, theta)
         @test tensor(p, tensor(d1, d2)) == p ⊗ d1 ⊗ d2
 
-        dstatic = displace(SVector{2}, SMatrix{2,2}, repr1, alpha1)
+        dstatic = displace(SVector{2}, SMatrix{2,2}, basis1, alpha1)
         tpstatic = dstatic ⊗ dstatic ⊗ dstatic
         @test tpstatic.disp isa SVector{6}
         @test tpstatic.symplectic isa SMatrix{6,6}
@@ -63,16 +63,16 @@
 
     @testset "actions" begin
         alpha = rand(ComplexF64)
-        d = displace(repr1, alpha)
-        v = vacuumstate(repr1)
-        c = coherentstate(repr1, alpha)
+        d = displace(basis1, alpha)
+        v = vacuumstate(basis1)
+        c = coherentstate(basis1, alpha)
         @test d * v == c
         @test apply!(v, d) == c
         
-        v1, v2 = vacuumstate(repr1), vacuumstate(repr1)
+        v1, v2 = vacuumstate(basis1), vacuumstate(basis1)
         alpha1, alpha2 = rand(ComplexF64), rand(ComplexF64)
-        d1, d2 = displace(repr1, alpha1), displace(repr1, alpha2)
-        c1, c2 = coherentstate(repr1, alpha1), coherentstate(repr1, alpha2)
+        d1, d2 = displace(basis1, alpha1), displace(basis1, alpha2)
+        c1, c2 = coherentstate(basis1, alpha1), coherentstate(basis1, alpha2)
         @test (d1 ⊗ d2) * (v1 ⊗ v2) == c1 ⊗ c2
     end
 end

--- a/test/test_unitaries.jl
+++ b/test/test_unitaries.jl
@@ -75,6 +75,10 @@
         p = phaseshift(qpairbasis, theta)
         @test tensor(p, tensor(d1, d2)) == p ⊗ d1 ⊗ d2
 
+        p_block = phaseshift(qblockbasis, theta)
+        p_blocks = phaseshift(2*qblockbasis, repeat([theta], 2*nmodes))
+        @test p_block ⊗ p_block == p_blocks
+
         dstatic = displace(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis, alpha1)
         tpstatic = dstatic ⊗ dstatic ⊗ dstatic
         @test tpstatic.disp isa SVector{6*nmodes}

--- a/test/test_wigner.jl
+++ b/test/test_wigner.jl
@@ -1,10 +1,11 @@
-@testitem "Wigner" begin
+@testitem "CanonicalForm" begin
     using Gabs
     using StaticArrays
 
+    repr1 = CanonicalForm(1)
     @testset "symplectic form" begin
-        Omega = symplecticform(2)
-        Omega_static = symplecticform(SMatrix{4, 4}, 2)
+        Omega = symplecticform(2*repr1)
+        Omega_static = symplecticform(SMatrix{4, 4}, 2*repr1)
         test_Omega = [0.0 1.0 0.0 0.0;
                       -1.0 0.0 0.0 0.0;
                       0.0 0.0 0.0 1.0;
@@ -14,8 +15,8 @@
     end
 
     @testset "wigner functions" begin
-        vac = vacuumstate()
-        c = coherentstate(1.0)
+        vac = vacuumstate(repr1)
+        c = coherentstate(repr1, 1.0)
         @test isapprox(wignerchar(vac, [0.0, 0.0]), 1.0 - 0.0im)
         @test wigner(vac, [rand(), rand()]) > 0.0
         @test wigner(c, [rand(), rand()]) > 0.0

--- a/test/test_wigner.jl
+++ b/test/test_wigner.jl
@@ -1,11 +1,11 @@
-@testitem "CanonicalForm" begin
+@testitem "Quadrature pair basis" begin
     using Gabs
     using StaticArrays
 
-    repr1 = CanonicalForm(1)
+    basis1 = QuadPairBasis(1)
     @testset "symplectic form" begin
-        Omega = symplecticform(2*repr1)
-        Omega_static = symplecticform(SMatrix{4, 4}, 2*repr1)
+        Omega = symplecticform(2*basis1)
+        Omega_static = symplecticform(SMatrix{4, 4}, 2*basis1)
         test_Omega = [0.0 1.0 0.0 0.0;
                       -1.0 0.0 0.0 0.0;
                       0.0 0.0 0.0 1.0;
@@ -15,8 +15,8 @@
     end
 
     @testset "wigner functions" begin
-        vac = vacuumstate(repr1)
-        c = coherentstate(repr1, 1.0)
+        vac = vacuumstate(basis1)
+        c = coherentstate(basis1, 1.0)
         @test isapprox(wignerchar(vac, [0.0, 0.0]), 1.0 - 0.0im)
         @test wigner(vac, [rand(), rand()]) > 0.0
         @test wigner(c, [rand(), rand()]) > 0.0


### PR DESCRIPTION
Discussed in #10. This will be a breaking change necessary for representing Gaussian states, unitaries, channels, etc in different symplectic representations. For instance, in the quadrature pair representation where the symplectic form is 
$`\Omega = \bigoplus_{i = 1}^{N}\begin{pmatrix} 0 & 1 \\ -1 & 0 \end{pmatrix}`$, we would express a displacement unitary operator as follows:
```
julia> nmodes = 1; repr = QuadPairBasis(nmodes);

julia> displace(basis, 1.0-im)
GaussianUnitary for 1 mode in QuadPairBasis representation.
displacement: 2-element Vector{Float64}:
  1.4142135623730951
 -1.4142135623730951
symplectic: 2×2 Matrix{Float64}:
 1.0  0.0
 0.0  1.0
```
Here, we have defined the symplectic basis `basis` to be of type `QuadPairBasis`, which wraps around the corresponding number of nodes. What's also nice (and was easy to implement) is that now we can form tensor products from predefined methods such as `displace`, e.g., we can make a tensor product of the same unitary:
```
julia> nmodes = 3; basis = QuadPairBasis(nmodes);

julia> displace(basis, 1.0-im)
GaussianUnitary for 3 modes in QuadPairBasis representation.
displacement: 6-element Vector{Float64}:
  1.4142135623730951
 -1.4142135623730951
  1.4142135623730951
 -1.4142135623730951
  1.4142135623730951
 -1.4142135623730951
symplectic: 6×6 Matrix{Float64}:
 1.0  0.0  0.0  0.0  0.0  0.0
 0.0  1.0  0.0  0.0  0.0  0.0
 0.0  0.0  1.0  0.0  0.0  0.0
 0.0  0.0  0.0  1.0  0.0  0.0
 0.0  0.0  0.0  0.0  1.0  0.0
 0.0  0.0  0.0  0.0  0.0  1.0
```
Or we can make a tensor product of different displacement unitaries by calling a vector of complex numbers (alphas) whose size is the number of modes of the output state, e.g.,:
```
julia> displace(basis, [1.0-im, 2.0-2.0im, 3.0-3.0im])
GaussianUnitary for 3 modes in QuadPairBasis representation.
displacement: 6-element Vector{Float64}:
  1.4142135623730951
 -1.4142135623730951
  2.8284271247461903
 -2.8284271247461903
  4.242640687119286
 -4.242640687119286
symplectic: 6×6 Matrix{Float64}:
 1.0  0.0  0.0  0.0  0.0  0.0
 0.0  1.0  0.0  0.0  0.0  0.0
 0.0  0.0  1.0  0.0  0.0  0.0
 0.0  0.0  0.0  1.0  0.0  0.0
 0.0  0.0  0.0  0.0  1.0  0.0
 0.0  0.0  0.0  0.0  0.0  1.0
```
There's still a few things that need to be done before this is merged:

- [x] Add support for `QuadBlockBasis`, the symplectic representation with form $`J = \begin{pmatrix} 0 & \mathbf{I}_N \\ -\mathbf{I}_N & 0 \end{pmatrix}`$.
- [x] Add more tests for each representation.
- [x] Update  docstrings.
- [x] Add note in docs manual about symplectic representations.
- [x] Update benchmarks.