### PR TITLE
Further establish symplectic interface

### DIFF
--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -17,9 +17,9 @@ relations (CCRs) of quantized continuous variable systems, manifestations of the
 appear everywhere. In Gabs, symplectic basis types must be defined from the beginning. Here's how they are laid out in this library:
 
 | canonical ordering | symplectic form | basis type |
-| --- | --- | --- |
-| $\mathbf{\hat{r}} = (\hat{x}_1, \hat{p}_1, \cdots, \hat{x}_N, \hat{p}_N)$ | $\mathbf{\Omega} = \begin{pmatrix} 0 & 1 \\ - 1 & 0 \end{pmatrix} \otimes \mathbf{I}_N$ | [`QuadPairBasis`](@ref) |
-| $\mathbf{\hat{r}} = (\hat{x}_1, \cdots, \hat{x}_N, \hat{p}_1, \cdots, \hat{p}_N)$ | $\mathbf{J} = \begin{pmatrix} 0 & \mathbf{I}_N \\ -\mathbf{I}_N & 0 \end{pmatrix}$ | [`QuadBlockBasis`](@ref) |
+| :---: | :---: | :---: |
+| $(\hat{x}_1, \hat{p}_1, \cdots, \hat{x}_N, \hat{p}_N)$ | $\begin{pmatrix} 0 & 1 \\ - 1 & 0 \end{pmatrix} \otimes \mathbf{I}_N$ | [`QuadPairBasis`](@ref) |
+| $(\hat{x}_1, \cdots, \hat{x}_N, \hat{p}_1, \cdots, \hat{p}_N)$ | $\begin{pmatrix} 0 & \mathbf{I}_N \\ -\mathbf{I}_N & 0 \end{pmatrix}$ | [`QuadBlockBasis`](@ref) |
 
 Each symplectic basis type is wrapped around the number of bosonic modes $N$. We can compose a larger symplectic basis
 with [`directsum`](@ref) or `⊕`, the direct sum symbol which can be typed in the Julia REPL as `\oplus<TAB>`:

--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -35,7 +35,7 @@ Of course, this type of behavior will occur implicitly when we take tensor produ
 in the following sections.
 
 !!! note
-    A matrix $\mathbf{S}$ of size $2N\times 2N$ is symplectic when it satisfies the relation $\mathbf{S} \mathbf{\Omega} \mathbf{S}^{\text{T}} = \mathbf{\Omega},$ where $\mathbf{\Omega}$ is an invertible skew-symmetric matrix.
+    A matrix $\mathbf{S}$ of size $2N\times 2N$ is symplectic when it satisfies the relation $\mathbf{S} \mathbf{\Omega} \mathbf{S}^{\text{T}} = \mathbf{\Omega},$ where $\mathbf{\Omega}$ is an invertible skew-symmetric matrix known as the *symplectic form*.
 
 ## Gaussian States
 

--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -10,6 +10,33 @@ Simply put, Gabs is a package for creating and transforming Gaussian bosonic sys
 mathematical explanations when appropriate. For comprehensive reviews of Gaussian
 quantum information, see the [suggested readings page](@ref References).
 
+## The Symplectic Formalism
+
+The underlying geometry of Gaussian informatics in the phase space is *symplectic*. From the basic canonical commutation
+relations (CCRs) of quantized continuous variable systems, manifestations of the symplectic group $\text{Sp}(2N, \mathbb{R})$
+appear everywhere. In Gabs, symplectic basis types must be defined from the beginning. Here's how they are laid out in this library:
+
+| canonical ordering | symplectic form | basis type |
+| --- | --- | --- |
+| $\mathbf{\hat{r}} = (\hat{x}_1, \hat{p}_1, \cdots, \hat{x}_N, \hat{p}_N)$ | $\mathbf{\Omega} = \begin{pmatrix} 0 & 1 \\ - 1 & 0 \end{pmatrix} \otimes \mathbf{I}_N$ | [`QuadPairBasis`](@ref) |
+| $\mathbf{\hat{r}} = (\hat{x}_1, \cdots, \hat{x}_N, \hat{p}_1, \cdots, \hat{p}_N)$ | $\mathbf{J} = \begin{pmatrix} 0 & \mathbf{I}_N \\ -\mathbf{I}_N & 0 \end{pmatrix}$ | [`QuadBlockBasis`](@ref) |
+
+Each symplectic basis type is wrapped around the number of bosonic modes $N$. We can compose a larger symplectic basis
+with [`directsum`](@ref) or `⊕`, the direct sum symbol which can be typed in the Julia REPL as `\oplus<TAB>`:
+
+```jldoctest
+julia> b = QuadPairBasis(2)
+QuadPairBasis(2)
+
+julia> b ⊕ b
+QuadPairBasis(4)
+```
+Of course, this type of behavior will occur implicitly when we take tensor products of Gaussian states and operators, as discussed
+in the following sections.
+
+!!! note
+    A matrix $\mathbf{S}$ of size $2N\times 2N$ is symplectic when it satisfies the relation $\mathbf{S} \mathbf{\Omega} \mathbf{S}^{\text{T}} = \mathbf{\Omega},$ where $\mathbf{\Omega}$ is an invertible skew-symmetric matrix.
+
 ## Gaussian States
 
 The star of this package is the [`GaussianState`](@ref) type, which allows us to initialize
@@ -59,10 +86,9 @@ covariance: 6×6 Matrix{Float64}:
  0.0  0.0  0.0  0.0  0.184235  0.748048
 ```
 
-Note that in the above example, we defined the symplectic basis of the Gaussian state to be [`QuadPairBasis`](@ref), which determines the arrangement of our quadrature field operators to be pairwise: $\mathbf{\hat{x}} = (q_1, p_1, q_2, p_2, q_3, p_3)^{\text{T}}$. If we wanted the field operators to be ordered blockwise, i.e.,
-$\mathbf{\hat{x}} = (q_1, q_2, q_3, p_1, p_2, p_3)^{\text{T}}$ then we would call [`QuadBlockBasis`](@ref) instead:
+Note that in the above example, we defined the symplectic basis to be of type [`QuadPairBasis`](@ref). If we wanted the canonical field operators to be ordered blockwise, then we would call [`QuadBlockBasis`](@ref) instead:
 
-```julia
+```jldoctest
 julia> basis = QuadBlockBasis(1);
 
 julia> coherentstate(basis, -1.0+im) ⊗ vacuumstate(basis) ⊗ squeezedstate(basis, 0.25, pi/4)
@@ -98,15 +124,6 @@ GaussianUnitary
 
 This is a rather clean way to characterize a large group of Gaussian transformations on
 an `N`-mode Gaussian bosonic system. As long as we have a displacement vector of size `2N` and symplectic matrix of size `2N x 2N`, we can create a Gaussian transformation. 
-
-!!! note
-    A matrix $\mathbf{S}$ of size $2N\times 2N$ is symplectic when it satisfies the following relation:
-
-    $$\mathbf{S} \mathbf{\Omega} \mathbf{S}^{\text{T}} = \mathbf{\Omega}.$$
-
-    In this library, we define symplectic matrices with respect to $\Omega$, the *symplectic form*, which satisfies the canonical
-    commutation relation $[\hat{x}_i, \hat{x}_j] = 2i\Omega_{ij}$, where $\hat{x}_i$ and $\hat{x}_j$
-    are quadrature field operators.
 
 This library has a number of predefined Gaussian unitaries, which are listed below:
 

--- a/src/Gabs.jl
+++ b/src/Gabs.jl
@@ -5,7 +5,7 @@ using BlockArrays: BlockedArray, BlockArray, Block, mortar
 import LinearAlgebra
 using LinearAlgebra: I, det, mul!, diagm, diag, qr
 
-import QuantumInterface: StateVector, AbstractOperator, apply!, tensor, ⊗
+import QuantumInterface: StateVector, AbstractOperator, apply!, tensor, ⊗, directsum, ⊕
 
 export 
     # types
@@ -13,7 +13,7 @@ export
     # symplectic representations
     QuadPairBasis, QuadBlockBasis,
     # operations
-    tensor, ⊗, apply!, ptrace, output, prob,
+    tensor, ⊗, directsum, ⊕, apply!, ptrace, output, prob,
     # predefined Gaussian states
     vacuumstate, thermalstate, coherentstate, squeezedstate, eprstate,
     # predefined Gaussian channels

--- a/src/channels.jl
+++ b/src/channels.jl
@@ -234,12 +234,12 @@ end
 
 function tensor(::Type{Td}, ::Type{Tt}, op1::GaussianChannel, op2::GaussianChannel) where {Td,Tt}
     disp, transform, noise = _tensor(op1, op2)
-    return GaussianChannel(op1.basis + op2.basis, Td(disp), Tt(transform), Tt(noise))
+    return GaussianChannel(op1.basis ⊕ op2.basis, Td(disp), Tt(transform), Tt(noise))
 end
 tensor(::Type{T}, op1::GaussianChannel, op2::GaussianChannel) where {T} = tensor(T, T, op1, op2)
 function tensor(op1::GaussianChannel, op2::GaussianChannel)
     disp, transform, noise = _tensor(op1, op2)
-    return GaussianChannel(op1.basis + op2.basis, disp, transform, noise)
+    return GaussianChannel(op1.basis ⊕ op2.basis, disp, transform, noise)
 end
 function _tensor(op1::GaussianChannel{B1,D1,T1}, op2::GaussianChannel{B2,D2,T2}) where {B1<:QuadPairBasis,B2<:QuadPairBasis,D1,D2,T1,T2}
     basis1, basis2 = op1.basis, op2.basis

--- a/src/measurements.jl
+++ b/src/measurements.jl
@@ -158,7 +158,7 @@ function output(meas::Generaldyne)
         _promote_output_matrix(typeof(outcome.covar), covarAB, (2*(sysbasis.nmodes - outbasis.nmodes), 2*outbasis.nmodes)))
     # map subsystem A
     meanA′, covarA′ = _generaldyne_map(meanA′, meanB′, covarA′, covarB′, covarAB′, sys, outcome)
-    return GaussianState(sysbasis - outbasis, meanA′, covarA′)
+    return GaussianState(typeof(outbasis)(sysbasis.nmodes-outbasis.nmodes) , meanA′, covarA′)
 end
 
 """

--- a/src/states.jl
+++ b/src/states.jl
@@ -467,13 +467,13 @@ covariance: 4×4 Matrix{Float64}:
 function tensor(::Type{Tm}, ::Type{Tc}, state1::GaussianState, state2::GaussianState) where {Tm,Tc}
     typeof(state1.basis) == typeof(state2.basis) || throw(ArgumentError(SYMPLECTIC_ERROR))
     mean, covar = _tensor(state1, state2)
-    return GaussianState(state1.basis + state2.basis, Tm(mean), Tc(covar))
+    return GaussianState(state1.basis ⊕ state2.basis, Tm(mean), Tc(covar))
 end
 tensor(::Type{T}, state1::GaussianState, state2::GaussianState) where {T} = tensor(T, T, state1, state2)
 function tensor(state1::GaussianState, state2::GaussianState)
     typeof(state1.basis) == typeof(state2.basis) || throw(ArgumentError(SYMPLECTIC_ERROR))
     mean, covar = _tensor(state1, state2)
-    return GaussianState(state1.basis + state2.basis, mean, covar)
+    return GaussianState(state1.basis ⊕ state2.basis, mean, covar)
 end
 function _tensor(state1::GaussianState{B1,M1,V1}, state2::GaussianState{B2,M2,V2}) where {B1<:QuadPairBasis,B2<:QuadPairBasis,M1,M2,V1,V2}
     mean1, mean2 = state1.mean, state2.mean

--- a/src/symplectic.jl
+++ b/src/symplectic.jl
@@ -19,14 +19,17 @@ end
 function Base.show(io::IO, x::SymplecticBasis)
     print(io, "$(nameof(typeof(x)))($(x.nmodes))")
 end
-function Base.:(*)(n::N, repr2::R) where {N<:Number,R<:SymplecticBasis}
-    R(n*repr2.nmodes)
+function Base.:(*)(n::N, basis::R) where {N<:Number,R<:SymplecticBasis}
+    R(n*basis.nmodes)
 end
-function Base.:(+)(repr1::R, repr2::R) where {R<:SymplecticBasis}
-    R(repr1.nmodes + repr2.nmodes)
-end
-function Base.:(-)(repr1::R, repr2::R) where {R<:SymplecticBasis}
-    R(repr1.nmodes - repr2.nmodes)
+
+"""
+    directsum(basis1::SymplecticBasis, basis2::SymplecticBasis)
+
+Compute the direct sum of symplectic bases.
+"""
+function directsum(basis1::R, basis2::R) where {R<:SymplecticBasis}
+    R(basis1.nmodes + basis2.nmodes)
 end
 
 """

--- a/src/unitaries.jl
+++ b/src/unitaries.jl
@@ -573,12 +573,12 @@ end
 function tensor(::Type{Td}, ::Type{Ts}, op1::GaussianUnitary, op2::GaussianUnitary) where {Td,Ts}
     typeof(op1.basis) == typeof(op2.basis) || throw(ArgumentError(SYMPLECTIC_ERROR))
     disp, symplectic = _tensor(op1, op2)
-    return GaussianUnitary(op1.basis + op2.basis, Td(disp), Ts(symplectic))
+    return GaussianUnitary(op1.basis ⊕ op2.basis, Td(disp), Ts(symplectic))
 end
 tensor(::Type{T}, op1::GaussianUnitary, op2::GaussianUnitary) where {T} = tensor(T, T, op1, op2)
 function tensor(op1::GaussianUnitary, op2::GaussianUnitary)
     disp, symplectic = _tensor(op1, op2)
-    return GaussianUnitary(op1.basis + op2.basis, disp, symplectic)
+    return GaussianUnitary(op1.basis ⊕ op2.basis, disp, symplectic)
 end
 function _tensor(op1::GaussianUnitary{B1,D1,S1}, op2::GaussianUnitary{B2,D2,S2}) where {B1<:QuadPairBasis,B2<:QuadPairBasis,D1,D2,S1,S2}
     basis1, basis2 = op1.basis, op2.basis

--- a/test/test_measurements.jl
+++ b/test/test_measurements.jl
@@ -13,7 +13,7 @@
 
         coh = coherentstate(basis, 1.0+im)
         cohs = coh ⊗ vac ⊗ coh ⊗ vac
-        epr = eprstate(basis + basis, 1.0, 3.0)
+        epr = eprstate(basis ⊕ basis, 1.0, 3.0)
         gd2 = Generaldyne(cohs, epr, [1, 4])
         out2 = output(gd2)
         @test isequal(out2, vac ⊗ coh)


### PR DESCRIPTION
Addresses #18. Also adds `directsum` and `⊕` to public API from QuantumInterface.jl so that symplectic bases can be composed.