### PR TITLE
fix `ptrace(::GaussianState, ::AbstractVector)` to preserve mode correlations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # News
 
+## v1.2.4 - 2024-12-30
+
+- **(fix)** Preserve mode correlations in `ptrace``.
+  
 ## v1.2.3 - 2024-12-26
 
 - Enable propagation of dual types in Gabs custom types.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Gabs"
 uuid = "0eb812ee-a11f-4f5e-b8d4-bb8a44f06f50"
 authors = ["Andrew Kille"]
-version = "1.2.3"
+version = "1.2.4"
 
 [deps]
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"

--- a/src/states.jl
+++ b/src/states.jl
@@ -653,10 +653,17 @@ function _ptrace(state::GaussianState{B,M,V}, indices::T) where {B<:QuadPairBasi
     covar′ = zeros(Vt, 2*idxlength, 2*idxlength)
     @inbounds for i in eachindex(indices)
         idx = indices[i]
-        covar′[2*i-1, 2*i-1] = covar[2*idx-1, 2*idx-1]
-        covar′[2*i-1, 2*i] = covar[2*idx-1, 2*idx]
-        covar′[2*i, 2*i-1] = covar[2*idx, 2*idx-1]
-        covar′[2*i, 2*i] = covar[2*idx, 2*idx]
+        @inbounds for j in i:idxlength
+            otheridx = indices[j]
+            covar′[2*i-1, 2*j-1] = covar[2*idx-1, 2*otheridx-1]
+            covar′[2*i-1, 2*j] = covar[2*idx-1, 2*otheridx]
+            covar′[2*i, 2*j-1] = covar[2*idx, 2*otheridx-1]
+            covar′[2*i, 2*j] = covar[2*idx, 2*otheridx]
+            covar′[2*j-1, 2*i-1] = covar[2*otheridx-1, 2*idx-1]
+            covar′[2*j-1, 2*i] = covar[2*otheridx-1, 2*idx]
+            covar′[2*j, 2*i-1] = covar[2*otheridx, 2*idx-1]
+            covar′[2*j, 2*i] = covar[2*otheridx, 2*idx]
+        end
     end 
     mean′′ = _promote_output_vector(typeof(mean), mean′, 2*idxlength)
     covar′′ = _promote_output_matrix(typeof(covar), covar′, 2*idxlength)
@@ -700,7 +707,9 @@ function _ptrace(state::GaussianState{B,M,V}, indices::T) where {B<:QuadBlockBas
             covar′[i,j] = covar[idx,otheridx]
             covar′[j,i] = covar[otheridx,idx]
             covar′[i+idxlength,j] = covar[idx+nmodes,otheridx]
+            covar′[i,j+idxlength] = covar[idx,otheridx+nmodes]
             covar′[j,i+idxlength] = covar[otheridx,idx+nmodes]
+            covar′[j+idxlength,i] = covar[otheridx+nmodes,idx]
             covar′[i+idxlength,j+idxlength] = covar[idx+nmodes, otheridx+nmodes]
             covar′[j+idxlength,i+idxlength] = covar[otheridx+nmodes, idx+nmodes]
         end

--- a/test/test_states.jl
+++ b/test/test_states.jl
@@ -114,6 +114,15 @@
 
         @test ptrace(SVector{2}, SMatrix{2,2}, state_qpair, 1) isa GaussianState
         @test ptrace(SVector{4}, SMatrix{4,4}, state_qpair, [1, 3]) isa GaussianState
+
+        qpairbasis4 = QuadPairBasis(4)
+        qblockbasis4 = QuadBlockBasis(4)
+
+        eprstates_qpair = eprstate(qpairbasis4, r, theta)
+        eprstates_qblock = eprstate(qblockbasis4, r, theta)
+
+        @test ptrace(eprstates_qpair, [1, 2]) == eprstate(QuadPairBasis(2), r, theta)
+        @test ptrace(eprstates_qblock, [1, 2]) == eprstate(QuadBlockBasis(2), r, theta)
     end
 
     @testset "symplectic spectrum" begin


### PR DESCRIPTION
`ptrace` didn't capture correlations between multi-mode Gaussian subsystems.
Before:
```
julia> state = eprstate(QuadPairBasis(4), 1.0, 2.0)
GaussianState for 4 modes.
  symplectic basis: QuadPairBasis
mean: 8-element Vector{Float64}:
 0.0
 0.0
 0.0
 0.0
 0.0
 0.0
 0.0
 0.0
covariance: 8×8 Matrix{Float64}:
  1.8811     0.0        0.754653  -1.64895    0.0        0.0        0.0        0.0
  0.0        1.8811    -1.64895   -0.754653   0.0        0.0        0.0        0.0
  0.754653  -1.64895    1.8811     0.0        0.0        0.0        0.0        0.0
 -1.64895   -0.754653   0.0        1.8811     0.0        0.0        0.0        0.0
  0.0        0.0        0.0        0.0        1.8811     0.0        0.754653  -1.64895
  0.0        0.0        0.0        0.0        0.0        1.8811    -1.64895   -0.754653
  0.0        0.0        0.0        0.0        0.754653  -1.64895    1.8811     0.0
  0.0        0.0        0.0        0.0       -1.64895   -0.754653   0.0        1.8811

julia> ptrace(state, [1,2])
GaussianState for 2 modes.
  symplectic basis: QuadPairBasis
mean: 4-element Vector{Float64}:
 0.0
 0.0
 0.0
 0.0
covariance: 4×4 Matrix{Float64}:
 1.8811  0.0     0.0     0.0
 0.0     1.8811  0.0     0.0
 0.0     0.0     1.8811  0.0
 0.0     0.0     0.0     1.8811
```
After:
```
julia> ptrace(state, [1,2])
GaussianState for 2 modes.
  symplectic basis: QuadPairBasis
mean: 4-element Vector{Float64}:
 0.0
 0.0
 0.0
 0.0
covariance: 4×4 Matrix{Float64}:
  1.8811     0.0        0.754653  -1.64895
  0.0        1.8811    -1.64895   -0.754653
  0.754653  -1.64895    1.8811     0.0
 -1.64895   -0.754653   0.0        1.8811
```