### PR TITLE
fix: correct the rendering of Latexify-based covariance matrix

### DIFF
--- a/docs/src/tutorials.md
+++ b/docs/src/tutorials.md
@@ -163,14 +163,14 @@ julia> newst = ptrace(op * st, 1);
 Use [Latexify](https://github.com/korsbo/Latexify.jl) to render the covariance matrix of `newst` in LaTeX using `Latexify.latexify(newst.covar)`:
 
 ```math
-\\begin{equation}
-\\left[
-\\begin{array}{cc}
-\\left( 0.5 \\cosh\\left( 2 r \\right) \\sqrt{1 - \\tau} - 0.5 \\cos\\left( \\theta \\right) \\sinh\\left( 2 r \\right) \\sqrt{\\tau} \\right) \\sqrt{1 - \\tau} + \\left( 0.5 \\sqrt{\\tau} \\cosh\\left( 2 r \\right) - 0.5 \\cos\\left( \\theta \\right) \\sinh\\left( 2 r \\right) \\sqrt{1 - \\tau} \\right) \\sqrt{\\tau} &  - \\sinh\\left( 2 r \\right) \\sin\\left( \\theta \\right) \\sqrt{\\tau} \\sqrt{1 - \\tau} \\\\
- - \\sinh\\left( 2 r \\right) \\sin\\left( \\theta \\right) \\sqrt{\\tau} \\sqrt{1 - \\tau} & \\left( 0.5 \\cosh\\left( 2 r \\right) \\sqrt{1 - \\tau} + 0.5 \\cos\\left( \\theta \\right) \\sinh\\left( 2 r \\right) \\sqrt{\\tau} \\right) \\sqrt{1 - \\tau} + \\left( 0.5 \\sqrt{\\tau} \\cosh\\left( 2 r \\right) + 0.5 \\cos\\left( \\theta \\right) \\sinh\\left( 2 r \\right) \\sqrt{1 - \\tau} \\right) \\sqrt{\\tau} \\\\
-\\end{array}
-\\right]
-\\end{equation}
+\begin{equation}
+\left[
+\begin{array}{cc}
+\left( 0.5 \cosh\left( 2 r \right) \sqrt{1 - \tau} - 0.5 \cos\left( \theta \right) \sinh\left( 2 r \right) \sqrt{\tau} \right) \sqrt{1 - \tau} + \left( 0.5 \sqrt{\tau} \cosh\left( 2 r \right) - 0.5 \cos\left( \theta \right) \sinh\left( 2 r \right) \sqrt{1 - \tau} \right) \sqrt{\tau} &  - \sinh\left( 2 r \right) \sin\left( \theta \right) \sqrt{\tau} \sqrt{1 - \tau} \\
+ - \sinh\left( 2 r \right) \sin\left( \theta \right) \sqrt{\tau} \sqrt{1 - \tau} & \left( 0.5 \cosh\left( 2 r \right) \sqrt{1 - \tau} + 0.5 \cos\left( \theta \right) \sinh\left( 2 r \right) \sqrt{\tau} \right) \sqrt{1 - \tau} + \left( 0.5 \sqrt{\tau} \cosh\left( 2 r \right) + 0.5 \cos\left( \theta \right) \sinh\left( 2 r \right) \sqrt{1 - \tau} \right) \sqrt{\tau} \\
+\end{array}
+\right]
+\end{equation}
 ```
 
 ## GPU Acceleration

--- a/docs/src/tutorials.md
+++ b/docs/src/tutorials.md
@@ -160,7 +160,7 @@ symplectic: 4×4 Matrix{Num}:
 julia> newst = ptrace(op * st, 1);
 ```
 
-Use [Latexify](https://github.com/korsbo/Latexify.jl) to render the covariance matrix of `newst` in LaTeX using `Latexify.latexify(newst.covar)`:
+Use [Latexify](https://github.com/korsbo/Latexify.jl) to render the covariance matrix of `newst` in LaTeX with the command `latexify(newst.covar) |> print`:
 
 ```math
 \begin{equation}


### PR DESCRIPTION
This PR aims to fix the rendering of this equation 😅 I had used double` //` to escape the `/ `but I think using single back slash does not cause error here. I saw that `/` works fine and does not throw error while building package.

![image](https://github.com/user-attachments/assets/11f19b61-c197-42fc-9a9c-6c18114a36ac)

Apologies for this rendering mistake! 🙏🏼 

