### PR TITLE
Add ħ = 2 as default Gabs convention and clean up docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## v1.2.9 - dev
 
 - Add seminal papers section to documentation.
+- **(breaking)** Add `hbar=2` as default convention in Gabs.
+- Add kwarg to predefined Gaussian methods to specify `hbar`.
+- Clean up docstrings to no longer include uncompiled LaTeX.
 
 ## v1.2.8 - 2025-02-06
 

--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -210,12 +210,12 @@ mean: 6-element Vector{Float64}:
   0.0
   0.0
 covariance: 6×6 Matrix{Float64}:
- 1.0  0.0  0.0  0.0  0.0       0.0
- 0.0  1.0  0.0  0.0  0.0       0.0
- 0.0  0.0  1.0  0.0  0.0       0.0
- 0.0  0.0  0.0  1.0  0.0       0.0
- 0.0  0.0  0.0  0.0  0.759156  0.36847
- 0.0  0.0  0.0  0.0  0.36847   1.4961
+ 1.0  0.0  0.0  0.0   0.0        0.0
+ 0.0  1.0  0.0  0.0   0.0        0.0
+ 0.0  0.0  1.0  0.0   0.0        0.0
+ 0.0  0.0  0.0  1.0   0.0        0.0
+ 0.0  0.0  0.0  0.0   0.759156  -0.36847
+ 0.0  0.0  0.0  0.0  -0.36847    1.4961
 ```
 
 Note that in the above example, we defined the symplectic basis to be of type [`QuadPairBasis`](@ref). If we wanted the canonical field operators to be ordered blockwise, then we would call [`QuadBlockBasis`](@ref) instead:
@@ -234,12 +234,12 @@ mean: 6-element Vector{Float64}:
   0.0
   0.0
 covariance: 6×6 Matrix{Float64}:
- 1.0  0.0  0.0       0.0  0.0  0.0
- 0.0  1.0  0.0       0.0  0.0  0.0
- 0.0  0.0  0.759156  0.0  0.0  0.36847
- 0.0  0.0  0.0       1.0  0.0  0.0
- 0.0  0.0  0.0       0.0  1.0  0.0
- 0.0  0.0  0.36847   0.0  0.0  1.4961
+ 1.0  0.0   0.0       0.0  0.0   0.0
+ 0.0  1.0   0.0       0.0  0.0   0.0
+ 0.0  0.0   0.759156  0.0  0.0  -0.36847
+ 0.0  0.0   0.0       1.0  0.0   0.0
+ 0.0  0.0   0.0       0.0  1.0   0.0
+ 0.0  0.0  -0.36847   0.0  0.0   1.4961
 ```
 These tensor product methods are also available for Gaussian unitaries and channels:
 

--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -58,6 +58,9 @@ Listed below are supported predefined Gaussian states:
 Detailed discussions and mathematical descriptions for each of these states are given in the
 [Gaussian Zoos](@ref) page.
 
+!!! note
+    In Gabs, the default convention $\hbar = 2$ is used for the commutation relation $[\hat{x}, \hat{p}] = i\hbar$. To change this convention, pass a new value to `ħ` as a keyword argument in any predefined method that creates a Gaussian object. For instance, to change the convention to `ħ = 1` for a coherent state, call `coherentstate(basis, α, ħ = 1)`. This is a more performant and safer approach compared to setting a global variable in a package. An error will be thrown for operations between Gaussian objects with different `ħ` conventions.
+
 ## Gaussian Unitaries
 
 To transform Gaussian states into Gaussian states, we need Gaussian maps. Let's begin with the simplest Gaussian transformation, a unitary transformation, which can be created with the [`GaussianUnitary`](@ref) type:

--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -105,8 +105,8 @@ Listed below are a list of predefined Gaussian channels supported by Gabs:
     GaussianChannel for 1 mode.
       symplectic basis: QuadPairBasis
     displacement: 2-element Vector{Float64}:
-      1.4142135623730951
-     -1.4142135623730951
+      2.0
+     -2.0
     transform: 2×2 Matrix{Float64}:
      1.0  0.0
      0.0  1.0
@@ -200,8 +200,8 @@ julia> coherentstate(basis, -1.0+im) ⊗ vacuumstate(basis) ⊗ squeezedstate(ba
 GaussianState for 3 modes.
   symplectic basis: QuadPairBasis
 mean: 6-element Vector{Float64}:
- -1.4142135623730951
-  1.4142135623730951
+ -2.0
+  2.0
   0.0
   0.0
   0.0
@@ -211,8 +211,8 @@ covariance: 6×6 Matrix{Float64}:
  0.0  1.0  0.0  0.0  0.0       0.0
  0.0  0.0  1.0  0.0  0.0       0.0
  0.0  0.0  0.0  1.0  0.0       0.0
- 0.0  0.0  0.0  0.0  0.379578  0.184235
- 0.0  0.0  0.0  0.0  0.184235  0.748048
+ 0.0  0.0  0.0  0.0  0.759156  0.36847
+ 0.0  0.0  0.0  0.0  0.36847   1.4961
 ```
 
 Note that in the above example, we defined the symplectic basis to be of type [`QuadPairBasis`](@ref). If we wanted the canonical field operators to be ordered blockwise, then we would call [`QuadBlockBasis`](@ref) instead:
@@ -224,19 +224,19 @@ julia> coherentstate(basis, -1.0+im) ⊗ vacuumstate(basis) ⊗ squeezedstate(ba
 GaussianState for 3 modes.
   symplectic basis: QuadBlockBasis
 mean: 6-element Vector{Float64}:
- -1.4142135623730951
+ -2.0
   0.0
   0.0
-  1.4142135623730951
+  2.0
   0.0
   0.0
 covariance: 6×6 Matrix{Float64}:
  1.0  0.0  0.0       0.0  0.0  0.0
  0.0  1.0  0.0       0.0  0.0  0.0
- 0.0  0.0  0.379578  0.0  0.0  0.184235
+ 0.0  0.0  0.759156  0.0  0.0  0.36847
  0.0  0.0  0.0       1.0  0.0  0.0
  0.0  0.0  0.0       0.0  1.0  0.0
- 0.0  0.0  0.184235  0.0  0.0  0.748048
+ 0.0  0.0  0.36847   0.0  0.0  1.4961
 ```
 These tensor product methods are also available for Gaussian unitaries and channels:
 
@@ -321,12 +321,12 @@ julia> coherentstate(basis, 1.0-im)
 GaussianState for 3 modes.
   symplectic basis: QuadPairBasis
 mean: 6-element Vector{Float64}:
-  1.4142135623730951
- -1.4142135623730951
-  1.4142135623730951
- -1.4142135623730951
-  1.4142135623730951
- -1.4142135623730951
+  2.0
+ -2.0
+  2.0
+ -2.0
+  2.0
+ -2.0
 covariance: 6×6 Matrix{Float64}:
  1.0  0.0  0.0  0.0  0.0  0.0
  0.0  1.0  0.0  0.0  0.0  0.0
@@ -339,12 +339,12 @@ julia> coherentstate(basis, [1.0-im, 2.0-2.0im, 3.0-3.0im])
 GaussianState for 3 modes.
   symplectic basis: QuadPairBasis
 mean: 6-element Vector{Float64}:
-  1.4142135623730951
- -1.4142135623730951
-  2.8284271247461903
- -2.8284271247461903
-  4.242640687119286
- -4.242640687119286
+  2.0
+ -2.0
+  4.0
+ -4.0
+  6.0
+ -6.0
 covariance: 6×6 Matrix{Float64}:
  1.0  0.0  0.0  0.0  0.0  0.0
  0.0  1.0  0.0  0.0  0.0  0.0
@@ -366,30 +366,30 @@ julia> state = coherentstate(basis, [1.0-im, 2.0-2.0im]) ⊗ eprstate(basis, 2.0
 GaussianState for 4 modes.
   symplectic basis: QuadPairBasis
 mean: 8-element Vector{Float64}:
-  1.4142135623730951
- -1.4142135623730951
-  2.8284271247461903
- -2.8284271247461903
+  2.0
+ -2.0
+  4.0
+ -4.0
   0.0
   0.0
   0.0
   0.0
 covariance: 8×8 Matrix{Float64}:
- 1.0  0.0  0.0  0.0    0.0        0.0        0.0        0.0
- 0.0  1.0  0.0  0.0    0.0        0.0        0.0        0.0
- 0.0  0.0  1.0  0.0    0.0        0.0        0.0        0.0
- 0.0  0.0  0.0  1.0    0.0        0.0        0.0        0.0
- 0.0  0.0  0.0  0.0   13.6541     0.0       -6.82248  -11.8169
- 0.0  0.0  0.0  0.0    0.0       13.6541   -11.8169     6.82248
- 0.0  0.0  0.0  0.0   -6.82248  -11.8169    13.6541     0.0
- 0.0  0.0  0.0  0.0  -11.8169     6.82248    0.0       13.6541
+ 1.0  0.0  0.0  0.0    0.0       0.0       0.0       0.0
+ 0.0  1.0  0.0  0.0    0.0       0.0       0.0       0.0
+ 0.0  0.0  1.0  0.0    0.0       0.0       0.0       0.0
+ 0.0  0.0  0.0  1.0    0.0       0.0       0.0       0.0
+ 0.0  0.0  0.0  0.0   27.3082    0.0     -13.645   -23.6338
+ 0.0  0.0  0.0  0.0    0.0      27.3082  -23.6338   13.645
+ 0.0  0.0  0.0  0.0  -13.645   -23.6338   27.3082    0.0
+ 0.0  0.0  0.0  0.0  -23.6338   13.645     0.0      27.3082
 
 julia> ptrace(state, 1)
 GaussianState for 1 mode.
   symplectic basis: QuadPairBasis
 mean: 2-element Vector{Float64}:
-  1.4142135623730951
- -1.4142135623730951
+  2.0
+ -2.0
 covariance: 2×2 Matrix{Float64}:
  1.0  0.0
  0.0  1.0
@@ -398,15 +398,15 @@ julia> ptrace(state, [1, 4])
 GaussianState for 2 modes.
   symplectic basis: QuadPairBasis
 mean: 4-element Vector{Float64}:
-  1.4142135623730951
- -1.4142135623730951
+  2.0
+ -2.0
   0.0
   0.0
 covariance: 4×4 Matrix{Float64}:
  1.0  0.0   0.0      0.0
  0.0  1.0   0.0      0.0
- 0.0  0.0  13.6541   0.0
- 0.0  0.0   0.0     13.6541
+ 0.0  0.0  27.3082   0.0
+ 0.0  0.0   0.0     27.3082
 ```
 
 ## Symplectic Analysis

--- a/docs/src/tutorials.md
+++ b/docs/src/tutorials.md
@@ -47,8 +47,8 @@ julia> coherentstate(QuadPairBasis(1), 1.0-im)
 GaussianState for 1 mode.
   symplectic basis: QuadPairBasis
 mean: 2-element Vector{Float64}:
-  1.4142135623730951
- -1.4142135623730951
+  2.0
+ -2.0
 covariance: 2×2 Matrix{Float64}:
  1.0  0.0
  0.0  1.0
@@ -64,8 +64,8 @@ julia> state = coherentstate(SVector{2}, SMatrix{2,2}, QuadPairBasis(1), 1.0-im)
 GaussianState for 1 mode.
   symplectic basis: QuadPairBasis
 mean: 2-element SVector{2, Float64} with indices SOneTo(2):
-  1.4142135623730951
- -1.4142135623730951
+  2.0
+ -2.0
 covariance: 2×2 SMatrix{2, 2, Float64, 4} with indices SOneTo(2)×SOneTo(2):
  1.0  0.0
  0.0  1.0
@@ -74,10 +74,10 @@ julia> tp = state ⊗ state
 GaussianState for 2 modes.
   symplectic basis: QuadPairBasis
 mean: 4-element SVector{4, Float64} with indices SOneTo(4):
-  1.4142135623730951
- -1.4142135623730951
-  1.4142135623730951
- -1.4142135623730951
+  2.0
+ -2.0
+  2.0
+ -2.0
 covariance: 4×4 SMatrix{4, 4, Float64, 16} with indices SOneTo(4)×SOneTo(4):
  1.0  0.0  0.0  0.0
  0.0  1.0  0.0  0.0
@@ -90,8 +90,8 @@ julia> ptrace(SparseVector, SparseMatrixCSC, tp, 1)
 GaussianState for 1 mode.
   symplectic basis: QuadPairBasis
 mean: 2-element SparseVector{Float64, Int64} with 2 stored entries:
-  [1]  =  1.41421
-  [2]  =  -1.41421
+  [1]  =  2.0
+  [2]  =  -2.0
 covariance: 2×2 SparseMatrixCSC{Float64, Int64} with 2 stored entries:
  1.0   ⋅ 
   ⋅   1.0
@@ -107,8 +107,8 @@ Importantly, methods that create or manipulate a Gaussian state, such as [`tenso
     GaussianUnitary for 1 mode.
       symplectic basis: QuadPairBasis
     displacement: 2-element Vector{Float32}:
-      1.4142135
-     -1.4142135
+      2.0
+     -2.0
     symplectic: 2×2 Matrix{Float32}:
      1.0  0.0
      0.0  1.0
@@ -138,10 +138,10 @@ mean: 4-element Vector{Num}:
  0
  0
 covariance: 4×4 Matrix{Num}:
-         0.5cosh(2r)  -0.5cos(θ)*sinh(2r)  …  -0.5sinh(2r)*sin(θ)
- -0.5cos(θ)*sinh(2r)          0.5cosh(2r)                       0
-                   0  -0.5sinh(2r)*sin(θ)      0.5cos(θ)*sinh(2r)
- -0.5sinh(2r)*sin(θ)                    0             0.5cosh(2r)
+         cosh(2r)  -cos(θ)*sinh(2r)                 0  -sinh(2r)*sin(θ)
+ -cos(θ)*sinh(2r)          cosh(2r)  -sinh(2r)*sin(θ)                 0
+                0  -sinh(2r)*sin(θ)          cosh(2r)   cos(θ)*sinh(2r)
+ -sinh(2r)*sin(θ)                 0   cos(θ)*sinh(2r)          cosh(2r)
 
 julia> op = beamsplitter(b, τ)
 GaussianUnitary for 2 modes.
@@ -166,8 +166,8 @@ Use [Latexify](https://github.com/korsbo/Latexify.jl) to render the covariance m
 \begin{equation}
 \left[
 \begin{array}{cc}
-\left( 0.5 \cosh\left( 2 r \right) \sqrt{1 - \tau} - 0.5 \cos\left( \theta \right) \sinh\left( 2 r \right) \sqrt{\tau} \right) \sqrt{1 - \tau} + \left( 0.5 \sqrt{\tau} \cosh\left( 2 r \right) - 0.5 \cos\left( \theta \right) \sinh\left( 2 r \right) \sqrt{1 - \tau} \right) \sqrt{\tau} &  - \sinh\left( 2 r \right) \sin\left( \theta \right) \sqrt{\tau} \sqrt{1 - \tau} \\
- - \sinh\left( 2 r \right) \sin\left( \theta \right) \sqrt{\tau} \sqrt{1 - \tau} & \left( 0.5 \cosh\left( 2 r \right) \sqrt{1 - \tau} + 0.5 \cos\left( \theta \right) \sinh\left( 2 r \right) \sqrt{\tau} \right) \sqrt{1 - \tau} + \left( 0.5 \sqrt{\tau} \cosh\left( 2 r \right) + 0.5 \cos\left( \theta \right) \sinh\left( 2 r \right) \sqrt{1 - \tau} \right) \sqrt{\tau} \\
+\left( \cosh\left( 2 r \right) \sqrt{1 - \tau} - \cos\left( \theta \right) \sinh\left( 2 r \right) \sqrt{\tau} \right) \sqrt{1 - \tau} + \left( \sqrt{\tau} \cosh\left( 2 r \right) - \cos\left( \theta \right) \sinh\left( 2 r \right) \sqrt{1 - \tau} \right) \sqrt{\tau} &  - 2 \sinh\left( 2 r \right) \sin\left( \theta \right) \sqrt{\tau} \sqrt{1 - \tau} \\
+ - 2 \sinh\left( 2 r \right) \sin\left( \theta \right) \sqrt{\tau} \sqrt{1 - \tau} & \left( \cosh\left( 2 r \right) \sqrt{1 - \tau} + \cos\left( \theta \right) \sinh\left( 2 r \right) \sqrt{\tau} \right) \sqrt{1 - \tau} + \left( \sqrt{\tau} \cosh\left( 2 r \right) + \cos\left( \theta \right) \sinh\left( 2 r \right) \sqrt{1 - \tau} \right) \sqrt{\tau} \\
 \end{array}
 \right]
 \end{equation}

--- a/src/Gabs.jl
+++ b/src/Gabs.jl
@@ -3,7 +3,7 @@ module Gabs
 using BlockArrays: BlockedArray, BlockArray, Block, mortar
 
 import LinearAlgebra
-using LinearAlgebra: I, det, mul!, diagm, diag, qr, eigvals
+using LinearAlgebra: I, det, mul!, diag, qr, eigvals, Diagonal
 
 import QuantumInterface: StateVector, AbstractOperator, apply!, tensor, ⊗, directsum, ⊕
 

--- a/src/channels.jl
+++ b/src/channels.jl
@@ -332,7 +332,7 @@ Change the symplectic basis of a Gaussian channel.
 # Example
 
 ```jldoctest
-julia> ch = attenuator(QuadBlockBasis(2), 1.0, 2)
+julia> ch = attenuator(QuadBlockBasis(2), [1.0, 2.0], [2, 4])
 GaussianChannel for 2 modes.
   symplectic basis: QuadBlockBasis
 displacement: 4-element Vector{Float64}:
@@ -341,15 +341,15 @@ displacement: 4-element Vector{Float64}:
  0.0
  0.0
 transform: 4×4 Matrix{Float64}:
- 0.540302  0.0       0.0       0.0
- 0.0       0.540302  0.0       0.0
- 0.0       0.0       0.540302  0.0
- 0.0       0.0       0.0       0.540302
+ 0.540302   0.0       0.0        0.0
+ 0.0       -0.416147  0.0        0.0
+ 0.0        0.0       0.540302   0.0
+ 0.0        0.0       0.0       -0.416147
 noise: 4×4 Matrix{Float64}:
  1.41615  0.0      0.0      0.0
- 0.0      1.41615  0.0      0.0
+ 0.0      3.30729  0.0      0.0
  0.0      0.0      1.41615  0.0
- 0.0      0.0      0.0      1.41615
+ 0.0      0.0      0.0      3.30729
 
 julia> changebasis(QuadPairBasis, ch)
 GaussianChannel for 2 modes.
@@ -360,15 +360,15 @@ displacement: 4-element Vector{Float64}:
  0.0
  0.0
 transform: 4×4 Matrix{Float64}:
- 0.540302  0.0       0.0       0.0
- 0.0       0.540302  0.0       0.0
- 0.0       0.0       0.540302  0.0
- 0.0       0.0       0.0       0.540302
+ 0.540302  0.0        0.0        0.0
+ 0.0       0.540302   0.0        0.0
+ 0.0       0.0       -0.416147   0.0
+ 0.0       0.0        0.0       -0.416147
 noise: 4×4 Matrix{Float64}:
  1.41615  0.0      0.0      0.0
  0.0      1.41615  0.0      0.0
- 0.0      0.0      1.41615  0.0
- 0.0      0.0      0.0      1.41615
+ 0.0      0.0      3.30729  0.0
+ 0.0      0.0      0.0      3.30729
 ```
 """
 function changebasis(::Type{B1}, op::GaussianChannel{B2,D,S}) where {B1<:QuadBlockBasis,B2<:QuadPairBasis,D,S}

--- a/src/channels.jl
+++ b/src/channels.jl
@@ -61,16 +61,10 @@ by beam splitter rotation angle `theta` and thermal noise `n`.
 
 ## Mathematical description of an attenuator channel
 
-An attenuator channel, ``\\mathcal{E}_{\\theta}^{n_{\\text{th}}}``, where ``\\theta`` is
-the beam splitter rotation parameter and ``n_{\\text{th}} \\geq 1`` is the thermal noise parameter,
-is characterized by the displacement vector ``\\mathbf{d}``, transformation matrix ``\\mathbf{T}``,
-and noise matrix ``\\mathbf{N}``, expressed respectively as follows:
-
-```math
-\\mathbf{d} = \\mathbf{0},
-\\quad \\mathbf{T} = \\cos\\theta\\mathbf{I},
-\\qquad \\mathbf{N} = (\\sin\\theta)^2 n_{\\text{th}} \\mathbf{I}.
-```
+An attenuator channel, `E(θ, nₜₕ)`, where `θ` is
+the beam splitter rotation parameter and `nₜₕ ≥ 1` is the thermal noise parameter,
+is characterized by the zero displacement vector, transformation matrix `cos(θ)I`,
+and noise matrix `nₜₕsin²(θ)I`.
 
 ## Example
 
@@ -89,14 +83,14 @@ noise: 2×2 Matrix{Float64}:
  0.0   0.75
 ```
 """
-function attenuator(::Type{Td}, ::Type{Tt}, basis::SymplecticBasis{N}, theta::R, n::M) where {Td,Tt,N<:Int,R,M}
+function attenuator(::Type{Td}, ::Type{Tt}, basis::SymplecticBasis{N}, theta::R, n::M; ħ = 2) where {Td,Tt,N<:Int,R,M}
     disp, transform, noise = _attenuator(basis, theta, n)
-    return GaussianChannel(basis, Td(disp), Tt(transform), Tt(noise))
+    return GaussianChannel(basis, Td(disp), Tt(transform), Tt(noise); ħ = ħ)
 end
-attenuator(::Type{T}, basis::SymplecticBasis{N}, theta::R, n::M) where {T,N<:Int,R,M} = attenuator(T, T, basis, theta, n)
-function attenuator(basis::SymplecticBasis{N}, theta::R, n::M) where {N<:Int,R,M}
+attenuator(::Type{T}, basis::SymplecticBasis{N}, theta::R, n::M; ħ = 2) where {T,N<:Int,R,M} = attenuator(T, T, basis, theta, n; ħ = ħ)
+function attenuator(basis::SymplecticBasis{N}, theta::R, n::M; ħ = 2) where {N<:Int,R,M}
     disp, transform, noise = _attenuator(basis, theta, n)
-    return GaussianChannel(basis, disp, transform, noise)
+    return GaussianChannel(basis, disp, transform, noise; ħ = ħ)
 end
 function _attenuator(basis::Union{QuadPairBasis{N},QuadBlockBasis{N}}, theta::R, n::M) where {N<:Int,R<:Real,M<:Int}
     nmodes = basis.nmodes
@@ -151,16 +145,10 @@ by squeezing amplitude parameter `r` and thermal noise `n`.
 
 ## Mathematical description of an amplifier channel
 
-An amplifier channel, ``\\mathcal{A}_{\\theta}^{n_{\\text{th}}}``, where ``r`` is
-the squeezing amplitude parameter and ``n_{\\text{th}} \\geq 1`` is the thermal noise parameter,
-is characterized by the displacement vector ``\\mathbf{d}``, transformation matrix ``\\mathbf{T}``,
-and noise matrix ``\\mathbf{N}``, expressed respectively as follows:
-
-```math
-\\mathbf{d} = \\mathbf{0},
-\\quad \\mathbf{T} = \\cosh r\\mathbf{I},
-\\qquad \\mathbf{N} = (\\sinh r)^2 n_{\\text{th}} \\mathbf{I}.
-```
+An amplifier channel, `A(r, nₜₕ)`, where `r` is
+the squeezing amplitude parameter and `nₜₕ ≥ 1` is the thermal noise parameter,
+is characterized by the zero displacement vector, transformation matrix `cosh(r)I`,
+and noise matrix `nₜₕsinh²(r)I`.
 
 ## Example
 
@@ -179,14 +167,14 @@ noise: 2×2 Matrix{Float64}:
   0.0     39.4623
 ```
 """
-function amplifier(::Type{Td}, ::Type{Tt}, basis::SymplecticBasis{N}, r::R, n::M) where {Td,Tt,N<:Int,R,M}
+function amplifier(::Type{Td}, ::Type{Tt}, basis::SymplecticBasis{N}, r::R, n::M; ħ = 2) where {Td,Tt,N<:Int,R,M}
     disp, transform, noise = _amplifier(basis, r, n)
-    return GaussianChannel(basis, Td(disp), Tt(transform), Tt(noise))
+    return GaussianChannel(basis, Td(disp), Tt(transform), Tt(noise); ħ = ħ)
 end
-amplifier(::Type{T}, basis::SymplecticBasis{N}, r::R, n::M) where {T,N<:Int,R,M} = amplifier(T, T, basis, r, n)
-function amplifier(basis::SymplecticBasis{N}, r::R, n::M) where {N<:Int,R,M}
+amplifier(::Type{T}, basis::SymplecticBasis{N}, r::R, n::M; ħ = 2) where {T,N<:Int,R,M} = amplifier(T, T, basis, r, n; ħ = ħ)
+function amplifier(basis::SymplecticBasis{N}, r::R, n::M; ħ = 2) where {N<:Int,R,M}
     disp, transform, noise = _amplifier(basis, r, n)
-    return GaussianChannel(basis, disp, transform, noise)
+    return GaussianChannel(basis, disp, transform, noise; ħ = ħ)
 end
 function _amplifier(basis::Union{QuadPairBasis{N},QuadBlockBasis{N}}, r::R, n::M) where {N<:Int,R<:Real,M<:Int}
     nmodes = basis.nmodes

--- a/src/channels.jl
+++ b/src/channels.jl
@@ -228,14 +228,14 @@ function tensor(::Type{Td}, ::Type{Tt}, op1::GaussianChannel, op2::GaussianChann
     typeof(op1.basis) == typeof(op2.basis) || throw(ArgumentError(SYMPLECTIC_ERROR))
     op1.ħ == op2.ħ || throw(DimensionMismatch(HBAR_ERROR))
     disp, transform, noise = _tensor(op1, op2)
-    return GaussianChannel(op1.basis ⊕ op2.basis, Td(disp), Tt(transform), Tt(noise))
+    return GaussianChannel(op1.basis ⊕ op2.basis, Td(disp), Tt(transform), Tt(noise); ħ = op1.ħ)
 end
 tensor(::Type{T}, op1::GaussianChannel, op2::GaussianChannel) where {T} = tensor(T, T, op1, op2)
 function tensor(op1::GaussianChannel, op2::GaussianChannel)
     typeof(op1.basis) == typeof(op2.basis) || throw(ArgumentError(SYMPLECTIC_ERROR))
     op1.ħ == op2.ħ || throw(DimensionMismatch(HBAR_ERROR))
     disp, transform, noise = _tensor(op1, op2)
-    return GaussianChannel(op1.basis ⊕ op2.basis, disp, transform, noise)
+    return GaussianChannel(op1.basis ⊕ op2.basis, disp, transform, noise; ħ = op1.ħ)
 end
 function _tensor(op1::GaussianChannel{B1,D1,T1}, op2::GaussianChannel{B2,D2,T2}) where {B1<:QuadPairBasis,B2<:QuadPairBasis,D1,D2,T1,T2}
     basis1, basis2 = op1.basis, op2.basis

--- a/src/channels.jl
+++ b/src/channels.jl
@@ -226,14 +226,14 @@ end
 
 function tensor(::Type{Td}, ::Type{Tt}, op1::GaussianChannel, op2::GaussianChannel) where {Td,Tt}
     typeof(op1.basis) == typeof(op2.basis) || throw(ArgumentError(SYMPLECTIC_ERROR))
-    op1.ħ == op2.ħ || throw(DimensionMismatch(HBAR_ERROR))
+    op1.ħ == op2.ħ || throw(ArgumentError(HBAR_ERROR))
     disp, transform, noise = _tensor(op1, op2)
     return GaussianChannel(op1.basis ⊕ op2.basis, Td(disp), Tt(transform), Tt(noise); ħ = op1.ħ)
 end
 tensor(::Type{T}, op1::GaussianChannel, op2::GaussianChannel) where {T} = tensor(T, T, op1, op2)
 function tensor(op1::GaussianChannel, op2::GaussianChannel)
     typeof(op1.basis) == typeof(op2.basis) || throw(ArgumentError(SYMPLECTIC_ERROR))
-    op1.ħ == op2.ħ || throw(DimensionMismatch(HBAR_ERROR))
+    op1.ħ == op2.ħ || throw(ArgumentError(HBAR_ERROR))
     disp, transform, noise = _tensor(op1, op2)
     return GaussianChannel(op1.basis ⊕ op2.basis, disp, transform, noise; ħ = op1.ħ)
 end

--- a/src/channels.jl
+++ b/src/channels.jl
@@ -225,11 +225,15 @@ end
 ##
 
 function tensor(::Type{Td}, ::Type{Tt}, op1::GaussianChannel, op2::GaussianChannel) where {Td,Tt}
+    typeof(op1.basis) == typeof(op2.basis) || throw(ArgumentError(SYMPLECTIC_ERROR))
+    op1.ħ == op2.ħ || throw(DimensionMismatch(HBAR_ERROR))
     disp, transform, noise = _tensor(op1, op2)
     return GaussianChannel(op1.basis ⊕ op2.basis, Td(disp), Tt(transform), Tt(noise))
 end
 tensor(::Type{T}, op1::GaussianChannel, op2::GaussianChannel) where {T} = tensor(T, T, op1, op2)
 function tensor(op1::GaussianChannel, op2::GaussianChannel)
+    typeof(op1.basis) == typeof(op2.basis) || throw(ArgumentError(SYMPLECTIC_ERROR))
+    op1.ħ == op2.ħ || throw(DimensionMismatch(HBAR_ERROR))
     disp, transform, noise = _tensor(op1, op2)
     return GaussianChannel(op1.basis ⊕ op2.basis, disp, transform, noise)
 end

--- a/src/errors.jl
+++ b/src/errors.jl
@@ -28,3 +28,6 @@ WIGNER_ERROR = lazy"The length of your input array does not match the
 
 HEATMAP_ERROR = lazy"The input Gaussian state describes more than one mode. 
     A heat map visualization for a multi-mode Gaussian state is not possible."
+
+HBAR_ERROR = lazy"There are at least two different conventions for `ħ` used in this operation. Make sure
+    that each Gaussian object has the same convention for `ħ`."

--- a/src/measurements.jl
+++ b/src/measurements.jl
@@ -21,27 +21,7 @@ julia> basis = QuadPairBasis(1);
 
 julia> vac = vacuumstate(basis); coh = coherentstate(basis, 1.0-im);
 
-julia> state = vac ⊗ coh ⊗ vac ⊗ coh
-GaussianState for 4 modes.
-  symplectic basis: QuadPairBasis
-mean: 8-element Vector{Float64}:
-  0.0
-  0.0
-  1.4142135623730951
- -1.4142135623730951
-  0.0
-  0.0
-  1.4142135623730951
- -1.4142135623730951
-covariance: 8×8 Matrix{Float64}:
- 1.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
- 0.0  1.0  0.0  0.0  0.0  0.0  0.0  0.0
- 0.0  0.0  1.0  0.0  0.0  0.0  0.0  0.0
- 0.0  0.0  0.0  1.0  0.0  0.0  0.0  0.0
- 0.0  0.0  0.0  0.0  1.0  0.0  0.0  0.0
- 0.0  0.0  0.0  0.0  0.0  1.0  0.0  0.0
- 0.0  0.0  0.0  0.0  0.0  0.0  1.0  0.0
- 0.0  0.0  0.0  0.0  0.0  0.0  0.0  1.0
+julia> state = vac ⊗ coh ⊗ vac ⊗ coh;
 
 julia> Generaldyne(state, coh ⊗ vac ⊗ coh, [1, 3, 4])
 Generaldyne on indices [1, 3, 4]
@@ -102,27 +82,7 @@ julia> basis = QuadPairBasis(1);
 
 julia> vac = vacuumstate(basis); coh = coherentstate(basis, 1.0-im);
 
-julia> state = vac ⊗ coh ⊗ vac ⊗ coh
-GaussianState for 4 modes.
-  symplectic basis: QuadPairBasis
-mean: 8-element Vector{Float64}:
-  0.0
-  0.0
-  1.4142135623730951
- -1.4142135623730951
-  0.0
-  0.0
-  1.4142135623730951
- -1.4142135623730951
-covariance: 8×8 Matrix{Float64}:
- 1.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
- 0.0  1.0  0.0  0.0  0.0  0.0  0.0  0.0
- 0.0  0.0  1.0  0.0  0.0  0.0  0.0  0.0
- 0.0  0.0  0.0  1.0  0.0  0.0  0.0  0.0
- 0.0  0.0  0.0  0.0  1.0  0.0  0.0  0.0
- 0.0  0.0  0.0  0.0  0.0  1.0  0.0  0.0
- 0.0  0.0  0.0  0.0  0.0  0.0  1.0  0.0
- 0.0  0.0  0.0  0.0  0.0  0.0  0.0  1.0
+julia> state = vac ⊗ coh ⊗ vac ⊗ coh;
 
 julia> gd = Generaldyne(state, coh ⊗ vac ⊗ coh, [1, 3, 4])
 Generaldyne on indices [1, 3, 4]
@@ -135,8 +95,8 @@ julia> output(gd)
 GaussianState for 1 mode.
   symplectic basis: QuadPairBasis
 mean: 2-element Vector{Float64}:
-  1.4142135623730951
- -1.4142135623730951
+  2.0
+ -2.0
 covariance: 2×2 Matrix{Float64}:
  1.0  0.0
  0.0  1.0
@@ -200,27 +160,7 @@ julia> basis = QuadPairBasis(1);
 
 julia> vac = vacuumstate(basis); coh = coherentstate(basis, 1.0-im);
 
-julia> state = vac ⊗ coh ⊗ vac ⊗ coh
-GaussianState for 4 modes.
-  symplectic basis: QuadPairBasis
-mean: 8-element Vector{Float64}:
-  0.0
-  0.0
-  1.4142135623730951
- -1.4142135623730951
-  0.0
-  0.0
-  1.4142135623730951
- -1.4142135623730951
-covariance: 8×8 Matrix{Float64}:
- 1.0  0.0  0.0  0.0  0.0  0.0  0.0  0.0
- 0.0  1.0  0.0  0.0  0.0  0.0  0.0  0.0
- 0.0  0.0  1.0  0.0  0.0  0.0  0.0  0.0
- 0.0  0.0  0.0  1.0  0.0  0.0  0.0  0.0
- 0.0  0.0  0.0  0.0  1.0  0.0  0.0  0.0
- 0.0  0.0  0.0  0.0  0.0  1.0  0.0  0.0
- 0.0  0.0  0.0  0.0  0.0  0.0  1.0  0.0
- 0.0  0.0  0.0  0.0  0.0  0.0  0.0  1.0
+julia> state = vac ⊗ coh ⊗ vac ⊗ coh;
 
 julia> gd = Generaldyne(state, coh ⊗ vac ⊗ coh, [1, 3, 4])
 Generaldyne on indices [1, 3, 4]
@@ -230,7 +170,7 @@ outcome: GaussianState for 3 modes.
  (xType: Vector{Float64} | vType: Matrix{Float64})
 
 julia> prob(gd)
-0.029788549650438086
+0.2201092644728679
 ```
 """
 function prob(meas::Generaldyne)

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -1,6 +1,6 @@
 """
     purity(state::GaussianState)
 
-Calculate the purity of a Gaussian state, defined by `1/sqrt(det(V))`.
+Calculate the purity of a Gaussian state, defined by `1/sqrt((2/ħ) det(V))`.
 """
-purity(state::GaussianState) = 1/sqrt(det(state.covar))
+purity(x::GaussianState) = (b = x.basis; (x.ħ/2)^(b.nmodes)/sqrt(det(x.covar)))

--- a/src/randoms.jl
+++ b/src/randoms.jl
@@ -4,13 +4,13 @@
 Calculate a random Gaussian state in symplectic representation defined by `basis`.
 """
 function randstate(::Type{Tm}, ::Type{Tc}, basis::SymplecticBasis{N}; pure = false, ħ = 2) where {Tm,Tc,N<:Int}
-    mean, covar = _randstate(basis; pure = pure, ħ = 2)
-    return GaussianState(basis, Tm(mean), Tc(covar))
+    mean, covar = _randstate(basis; pure = pure, ħ = ħ)
+    return GaussianState(basis, Tm(mean), Tc(covar), ħ = ħ)
 end
-randstate(::Type{T}, basis::SymplecticBasis{N}; pure = false, ħ = 2) where {T,N<:Int} = randstate(T,T,basis; pure = pure, ħ = 2)
+randstate(::Type{T}, basis::SymplecticBasis{N}; pure = false, ħ = 2) where {T,N<:Int} = randstate(T,T,basis; pure = pure, ħ = ħ)
 function randstate(basis::SymplecticBasis{N}; pure = false, ħ = 2) where {N<:Int}
-    mean, covar = _randstate(basis; pure = pure, ħ = 2)
-    return GaussianState(basis, mean, covar)
+    mean, covar = _randstate(basis; pure = pure, ħ = ħ)
+    return GaussianState(basis, mean, covar, ħ = ħ)
 end
 function _randstate(basis::QuadPairBasis{N}; pure = false, ħ = 2) where {N<:Int}
     nmodes = basis.nmodes
@@ -20,6 +20,7 @@ function _randstate(basis::QuadPairBasis{N}; pure = false, ħ = 2) where {N<:Int
     # generate pure Gaussian state
     if pure
         mul!(covar, symp, symp')
+        covar .*= (ħ/2)
         return mean, covar
     end
     # create buffer for matrix multiplication
@@ -38,6 +39,7 @@ function _randstate(basis::QuadBlockBasis{N}; pure = false, ħ = 2) where {N<:In
     # generate pure Gaussian state
     if pure
         mul!(covar, symp, symp')
+        covar .*= (ħ/2)
         return mean, covar
     end
     # create buffer for matrix multiplication
@@ -54,16 +56,16 @@ end
 
 Calculate a random Gaussian unitary operator in symplectic representation defined by `basis`.
 """
-function randunitary(::Type{Td}, ::Type{Ts}, basis::SymplecticBasis{N}; passive = false) where {Td,Ts,N<:Int}
-    disp, symp = _randunitary(basis, passive)
-    return GaussianUnitary(basis, Td(disp), Ts(symp))
+function randunitary(::Type{Td}, ::Type{Ts}, basis::SymplecticBasis{N}; passive = false, ħ = 2) where {Td,Ts,N<:Int}
+    disp, symp = _randunitary(basis, passive = passive)
+    return GaussianUnitary(basis, Td(disp), Ts(symp), ħ = ħ)
 end
-randunitary(::Type{T}, basis::SymplecticBasis{N}; passive = false) where {T,N<:Int} = randunitary(T,T,basis; passive = passive)
-function randunitary(basis::SymplecticBasis{N}; passive = false) where {N<:Int}
-    disp, symp = _randunitary(basis, passive)
-    return GaussianUnitary(basis, disp, symp)
+randunitary(::Type{T}, basis::SymplecticBasis{N}; passive = false, ħ = 2) where {T,N<:Int} = randunitary(T,T,basis; passive = passive, ħ = ħ)
+function randunitary(basis::SymplecticBasis{N}; passive = false, ħ = 2) where {N<:Int}
+    disp, symp = _randunitary(basis, passive = passive)
+    return GaussianUnitary(basis, disp, symp, ħ = ħ)
 end
-function _randunitary(basis::SymplecticBasis{N}, passive) where {N<:Int}
+function _randunitary(basis::SymplecticBasis{N}; passive = false) where {N<:Int}
     nmodes = basis.nmodes
     disp = rand(2*nmodes)
     symp = randsymplectic(basis, passive = passive)
@@ -75,14 +77,14 @@ end
 
 Calculate a random Gaussian channel in symplectic representation defined by `basis`.
 """
-function randchannel(::Type{Td}, ::Type{Tt}, basis::SymplecticBasis{N}) where {Td,Tt,N<:Int}
+function randchannel(::Type{Td}, ::Type{Tt}, basis::SymplecticBasis{N}; ħ = 2) where {Td,Tt,N<:Int}
     disp, transform, noise = _randchannel(basis)
-    return GaussianChannel(basis, Td(disp), Tt(transform), Tt(noise))
+    return GaussianChannel(basis, Td(disp), Tt(transform), Tt(noise), ħ = ħ)
 end
-randchannel(::Type{T}, basis::SymplecticBasis{N}) where {T,N<:Int} = randchannel(T,T,basis)
-function randchannel(basis::SymplecticBasis{N}) where {N<:Int}
+randchannel(::Type{T}, basis::SymplecticBasis{N}; ħ = 2) where {T,N<:Int} = randchannel(T,T,basis; ħ = ħ)
+function randchannel(basis::SymplecticBasis{N}; ħ = 2) where {N<:Int}
     disp, transform, noise = _randchannel(basis)
-    return GaussianChannel(basis, disp, transform, noise)
+    return GaussianChannel(basis, disp, transform, noise, ħ = ħ)
 end
 function _randchannel(basis::SymplecticBasis{N}) where {N<:Int}
     nmodes = basis.nmodes

--- a/src/states.jl
+++ b/src/states.jl
@@ -64,8 +64,8 @@ mean: 2-element Vector{Float64}:
  0.0
  0.0
 covariance: 2×2 Matrix{Float64}:
- 4.5  0.0
- 0.0  4.5
+ 9.0  0.0
+ 0.0  9.0
 ```
 """
 function thermalstate(::Type{Tm}, ::Type{Tc}, basis::SymplecticBasis{N}, photons::P; ħ = 2) where {Tm,Tc,N<:Int,P}
@@ -129,8 +129,8 @@ julia> coherentstate(QuadPairBasis(1), 1.0+im)
 GaussianState for 1 mode.
   symplectic basis: QuadPairBasis
 mean: 2-element Vector{Float64}:
- 1.4142135623730951
- 1.4142135623730951
+ 2.0
+ 2.0
 covariance: 2×2 Matrix{Float64}:
  1.0  0.0
  0.0  1.0
@@ -198,8 +198,8 @@ mean: 2-element Vector{Float64}:
  0.0
  0.0
 covariance: 2×2 Matrix{Float64}:
- 0.356044  0.415496
- 0.415496  1.18704
+ 0.712088  0.830993
+ 0.830993  2.37407
 ```
 """
 function squeezedstate(::Type{Tm}, ::Type{Tc}, basis::SymplecticBasis{N}, r::R, theta::R; ħ = 2) where {Tm,Tc,N<:Int,R}
@@ -296,10 +296,10 @@ mean: 4-element Vector{Float64}:
  0.0
  0.0
 covariance: 4×4 Matrix{Float64}:
-  0.77154    0.0       -0.415496  -0.415496
-  0.0        0.77154   -0.415496   0.415496
- -0.415496  -0.415496   0.77154    0.0
- -0.415496   0.415496   0.0        0.77154
+  1.54308    0.0       -0.830993  -0.830993
+  0.0        1.54308   -0.830993   0.830993
+ -0.830993  -0.830993   1.54308    0.0
+ -0.830993   0.830993   0.0        1.54308
 ```
 """
 function eprstate(::Type{Tm}, ::Type{Tc}, basis::SymplecticBasis{N}, r::R, theta::R; ħ = 2) where {Tm,Tc,N<:Int,R}
@@ -433,15 +433,15 @@ julia> coherentstate(basis, 1.0+im) ⊗ thermalstate(basis, 2)
 GaussianState for 2 modes.
   symplectic basis: QuadPairBasis
 mean: 4-element Vector{Float64}:
- 1.4142135623730951
- 1.4142135623730951
+ 2.0
+ 2.0
  0.0
  0.0
 covariance: 4×4 Matrix{Float64}:
  1.0  0.0  0.0  0.0
  0.0  1.0  0.0  0.0
- 0.0  0.0  2.5  0.0
- 0.0  0.0  0.0  2.5
+ 0.0  0.0  5.0  0.0
+ 0.0  0.0  0.0  5.0
 ```
 """
 function tensor(::Type{Tm}, ::Type{Tc}, state1::GaussianState, state2::GaussianState) where {Tm,Tc}
@@ -455,7 +455,7 @@ function tensor(state1::GaussianState, state2::GaussianState)
     typeof(state1.basis) == typeof(state2.basis) || throw(ArgumentError(SYMPLECTIC_ERROR))
     state1.ħ == state2.ħ || throw(DimensionMismatch(HBAR_ERROR))
     mean, covar = _tensor(state1, state2)
-    return GaussianState(state1.basis ⊕ state2.basis, mean, covar; ; ħ = state1.ħ)
+    return GaussianState(state1.basis ⊕ state2.basis, mean, covar; ħ = state1.ħ)
 end
 function _tensor(state1::GaussianState{B1,M1,V1}, state2::GaussianState{B2,M2,V2}) where {B1<:QuadPairBasis,B2<:QuadPairBasis,M1,M2,V1,V2}
     mean1, mean2 = state1.mean, state2.mean
@@ -538,23 +538,7 @@ indicated by `indices`.
 ```jldoctest
 julia> basis = QuadPairBasis(1);
 
-julia> state = coherentstate(basis, 1.0+im) ⊗ thermalstate(basis, 2) ⊗ squeezedstate(basis, 3.0, pi/4)
-GaussianState for 3 modes.
-  symplectic basis: QuadPairBasis
-mean: 6-element Vector{Float64}:
- 1.4142135623730951
- 1.4142135623730951
- 0.0
- 0.0
- 0.0
- 0.0
-covariance: 6×6 Matrix{Float64}:
- 1.0  0.0  0.0  0.0   0.0       0.0
- 0.0  1.0  0.0  0.0   0.0       0.0
- 0.0  0.0  2.5  0.0   0.0       0.0
- 0.0  0.0  0.0  2.5   0.0       0.0
- 0.0  0.0  0.0  0.0  29.5414   71.3164
- 0.0  0.0  0.0  0.0  71.3164  172.174
+julia> state = coherentstate(basis, 1.0+im) ⊗ thermalstate(basis, 2) ⊗ squeezedstate(basis, 3.0, pi/4);
 
 julia> ptrace(state, 2)
 GaussianState for 1 mode.
@@ -563,22 +547,22 @@ mean: 2-element Vector{Float64}:
  0.0
  0.0
 covariance: 2×2 Matrix{Float64}:
- 2.5  0.0
- 0.0  2.5
+ 5.0  0.0
+ 0.0  5.0
 
 julia> ptrace(state, [1, 3])
 GaussianState for 2 modes.
   symplectic basis: QuadPairBasis
 mean: 4-element Vector{Float64}:
- 1.4142135623730951
- 1.4142135623730951
+ 2.0
+ 2.0
  0.0
  0.0
 covariance: 4×4 Matrix{Float64}:
- 1.0  0.0   0.0       0.0
- 0.0  1.0   0.0       0.0
- 0.0  0.0  29.5414   71.3164
- 0.0  0.0  71.3164  172.174
+ 1.0  0.0    0.0       0.0
+ 0.0  1.0    0.0       0.0
+ 0.0  0.0   59.0829  142.633
+ 0.0  0.0  142.633   344.348
 ```
 """
 function ptrace(::Type{Tm}, ::Type{Tc}, state::GaussianState, idx::N) where {Tm,Tc,N<:Int}
@@ -712,10 +696,10 @@ mean: 4-element Vector{Float64}:
  0.0
  0.0
 covariance: 4×4 Matrix{Float64}:
- 2.63575  0.0      1.64895  0.0
- 0.0      2.63575  0.0      1.64895
- 1.64895  0.0      1.12644  0.0
- 0.0      1.64895  0.0      1.12644
+ 5.2715   0.0      3.29789  0.0
+ 0.0      5.2715   0.0      3.29789
+ 3.29789  0.0      2.25289  0.0
+ 0.0      3.29789  0.0      2.25289
 
 julia> changebasis(QuadPairBasis, st)
 GaussianState for 2 modes.
@@ -726,10 +710,10 @@ mean: 4-element Vector{Float64}:
  0.0
  0.0
 covariance: 4×4 Matrix{Float64}:
- 2.63575  1.64895  0.0      0.0
- 1.64895  1.12644  0.0      0.0
- 0.0      0.0      2.63575  1.64895
- 0.0      0.0      1.64895  1.12644
+ 5.2715   3.29789  0.0      0.0
+ 3.29789  2.25289  0.0      0.0
+ 0.0      0.0      5.2715   3.29789
+ 0.0      0.0      3.29789  2.25289
 ```
 """
 function changebasis(::Type{B1}, state::GaussianState{B2,M,V}) where {B1<:QuadBlockBasis,B2<:QuadPairBasis,M,V}

--- a/src/states.jl
+++ b/src/states.jl
@@ -448,14 +448,14 @@ function tensor(::Type{Tm}, ::Type{Tc}, state1::GaussianState, state2::GaussianS
     typeof(state1.basis) == typeof(state2.basis) || throw(ArgumentError(SYMPLECTIC_ERROR))
     state1.ħ == state2.ħ || throw(DimensionMismatch(HBAR_ERROR))
     mean, covar = _tensor(state1, state2)
-    return GaussianState(state1.basis ⊕ state2.basis, Tm(mean), Tc(covar))
+    return GaussianState(state1.basis ⊕ state2.basis, Tm(mean), Tc(covar); ħ = state1.ħ)
 end
 tensor(::Type{T}, state1::GaussianState, state2::GaussianState) where {T} = tensor(T, T, state1, state2)
 function tensor(state1::GaussianState, state2::GaussianState)
     typeof(state1.basis) == typeof(state2.basis) || throw(ArgumentError(SYMPLECTIC_ERROR))
     state1.ħ == state2.ħ || throw(DimensionMismatch(HBAR_ERROR))
     mean, covar = _tensor(state1, state2)
-    return GaussianState(state1.basis ⊕ state2.basis, mean, covar)
+    return GaussianState(state1.basis ⊕ state2.basis, mean, covar; ; ħ = state1.ħ)
 end
 function _tensor(state1::GaussianState{B1,M1,V1}, state2::GaussianState{B2,M2,V2}) where {B1<:QuadPairBasis,B2<:QuadPairBasis,M1,M2,V1,V2}
     mean1, mean2 = state1.mean, state2.mean
@@ -583,21 +583,21 @@ covariance: 4×4 Matrix{Float64}:
 """
 function ptrace(::Type{Tm}, ::Type{Tc}, state::GaussianState, idx::N) where {Tm,Tc,N<:Int}
     mean′, covar′ = _ptrace(state, idx)
-    return GaussianState(typeof(state.basis)(1), Tm(mean′), Tc(covar′))
+    return GaussianState(typeof(state.basis)(1), Tm(mean′), Tc(covar′); ħ = state.ħ)
 end
 ptrace(::Type{T}, state::GaussianState, idx::N) where {T,N<:Int} = ptrace(T, T, state, idx)
 function ptrace(state::GaussianState, idx::N) where {N<:Int}
     mean′, covar′ = _ptrace(state, idx)
-    return GaussianState(typeof(state.basis)(1), mean′, covar′)
+    return GaussianState(typeof(state.basis)(1), mean′, covar′; ħ = state.ħ)
 end
 function ptrace(::Type{Tm}, ::Type{Tc}, state::GaussianState, indices::N) where {Tm,Tc,N<:AbstractVector}
     mean, covar = _ptrace(state, indices)
-    return GaussianState(typeof(state.basis)(length(indices)), Tm(mean), Tc(covar))
+    return GaussianState(typeof(state.basis)(length(indices)), Tm(mean), Tc(covar); ħ = state.ħ)
 end
 ptrace(::Type{T}, state::GaussianState, indices::N) where {T,N<:AbstractVector} = ptrace(T, T, state, indices)
 function ptrace(state::GaussianState, indices::T) where {T<:AbstractVector}
     mean, covar = _ptrace(state, indices)
-    return GaussianState(typeof(state.basis)(length(indices)), mean, covar)
+    return GaussianState(typeof(state.basis)(length(indices)), mean, covar; ħ = state.ħ)
 end
 function _ptrace(state::GaussianState{B,M,V}, idx::T) where {B<:QuadPairBasis,M,V,T<:Int}
     idxV = 2*idx-1:(2*idx)

--- a/src/states.jl
+++ b/src/states.jl
@@ -198,8 +198,8 @@ mean: 2-element Vector{Float64}:
  0.0
  0.0
 covariance: 2×2 Matrix{Float64}:
- 0.712088  0.830993
- 0.830993  2.37407
+  0.712088  -0.830993
+ -0.830993   2.37407
 ```
 """
 function squeezedstate(::Type{Tm}, ::Type{Tc}, basis::SymplecticBasis{N}, r::R, theta::R; ħ = 2) where {Tm,Tc,N<:Int,R}
@@ -219,8 +219,8 @@ function _squeezedstate(basis::QuadPairBasis{N}, r::R, theta::R; ħ = 2) where {
     ct, st = cos(theta), sin(theta)
     @inbounds for i in Base.OneTo(nmodes)
         covar[2*i-1, 2*i-1] = (ħ/2) * (cr - sr*ct)
-        covar[2*i-1, 2*i] = (ħ/2) * sr * st
-        covar[2*i, 2*i-1] = (ħ/2) * sr * st
+        covar[2*i-1, 2*i] = -(ħ/2) * sr * st
+        covar[2*i, 2*i-1] = -(ħ/2) * sr * st
         covar[2*i, 2*i] = (ħ/2) * (cr + sr*ct)
     end
     return mean, covar
@@ -234,8 +234,8 @@ function _squeezedstate(basis::QuadPairBasis{N}, r::R, theta::R; ħ = 2) where {
         cr, sr = cosh(2*r[i]), sinh(2*r[i])
         ct, st = cos(theta[i]), sin(theta[i])
         covar[2*i-1, 2*i-1] = (ħ/2) * (cr - sr*ct)
-        covar[2*i-1, 2*i] = (ħ/2) * sr * st
-        covar[2*i, 2*i-1] = (ħ/2) * sr * st
+        covar[2*i-1, 2*i] = -(ħ/2) * sr * st
+        covar[2*i, 2*i-1] = -(ħ/2) * sr * st
         covar[2*i, 2*i] = (ħ/2) * (cr + sr*ct)
     end
     return mean, covar
@@ -248,8 +248,8 @@ function _squeezedstate(basis::QuadBlockBasis{N}, r::R, theta::R; ħ = 2) where 
     ct, st = cos(theta), sin(theta)
     @inbounds for i in Base.OneTo(nmodes)
         covar[i, i] = (ħ/2) * (cr - sr*ct)
-        covar[i, i+nmodes] = (ħ/2) * sr * st
-        covar[i+nmodes, i] = (ħ/2) * sr * st
+        covar[i, i+nmodes] = -(ħ/2) * sr * st
+        covar[i+nmodes, i] = -(ħ/2) * sr * st
         covar[i+nmodes, i+nmodes] = (ħ/2) * (cr + sr*ct)
     end
     return mean, covar
@@ -263,8 +263,8 @@ function _squeezedstate(basis::QuadBlockBasis{N}, r::R, theta::R; ħ = 2) where 
         cr, sr = cosh(2*r[i]), sinh(2*r[i])
         ct, st = cos(theta[i]), sin(theta[i])
         covar[i, i] = (ħ/2) * (cr - sr*ct)
-        covar[i, i+nmodes] = (ħ/2) * sr * st
-        covar[i+nmodes, i] = (ħ/2) * sr * st
+        covar[i, i+nmodes] = -(ħ/2) * sr * st
+        covar[i+nmodes, i] = -(ħ/2) * sr * st
         covar[i+nmodes, i+nmodes] = (ħ/2) * (cr + sr*ct)
     end
     return mean, covar
@@ -559,10 +559,10 @@ mean: 4-element Vector{Float64}:
  0.0
  0.0
 covariance: 4×4 Matrix{Float64}:
- 1.0  0.0    0.0       0.0
- 0.0  1.0    0.0       0.0
- 0.0  0.0   59.0829  142.633
- 0.0  0.0  142.633   344.348
+ 1.0  0.0     0.0        0.0
+ 0.0  1.0     0.0        0.0
+ 0.0  0.0    59.0829  -142.633
+ 0.0  0.0  -142.633    344.348
 ```
 """
 function ptrace(::Type{Tm}, ::Type{Tc}, state::GaussianState, idx::N) where {Tm,Tc,N<:Int}
@@ -696,10 +696,10 @@ mean: 4-element Vector{Float64}:
  0.0
  0.0
 covariance: 4×4 Matrix{Float64}:
- 5.2715   0.0      3.29789  0.0
- 0.0      5.2715   0.0      3.29789
- 3.29789  0.0      2.25289  0.0
- 0.0      3.29789  0.0      2.25289
+  5.2715    0.0      -3.29789   0.0
+  0.0       5.2715    0.0      -3.29789
+ -3.29789   0.0       2.25289   0.0
+  0.0      -3.29789   0.0       2.25289
 
 julia> changebasis(QuadPairBasis, st)
 GaussianState for 2 modes.
@@ -710,10 +710,10 @@ mean: 4-element Vector{Float64}:
  0.0
  0.0
 covariance: 4×4 Matrix{Float64}:
- 5.2715   3.29789  0.0      0.0
- 3.29789  2.25289  0.0      0.0
- 0.0      0.0      5.2715   3.29789
- 0.0      0.0      3.29789  2.25289
+  5.2715   -3.29789   0.0       0.0
+ -3.29789   2.25289   0.0       0.0
+  0.0       0.0       5.2715   -3.29789
+  0.0       0.0      -3.29789   2.25289
 ```
 """
 function changebasis(::Type{B1}, state::GaussianState{B2,M,V}) where {B1<:QuadBlockBasis,B2<:QuadPairBasis,M,V}

--- a/src/states.jl
+++ b/src/states.jl
@@ -446,14 +446,14 @@ covariance: 4×4 Matrix{Float64}:
 """
 function tensor(::Type{Tm}, ::Type{Tc}, state1::GaussianState, state2::GaussianState) where {Tm,Tc}
     typeof(state1.basis) == typeof(state2.basis) || throw(ArgumentError(SYMPLECTIC_ERROR))
-    state1.ħ == state2.ħ || throw(DimensionMismatch(HBAR_ERROR))
+    state1.ħ == state2.ħ || throw(ArgumentError(HBAR_ERROR))
     mean, covar = _tensor(state1, state2)
     return GaussianState(state1.basis ⊕ state2.basis, Tm(mean), Tc(covar); ħ = state1.ħ)
 end
 tensor(::Type{T}, state1::GaussianState, state2::GaussianState) where {T} = tensor(T, T, state1, state2)
 function tensor(state1::GaussianState, state2::GaussianState)
     typeof(state1.basis) == typeof(state2.basis) || throw(ArgumentError(SYMPLECTIC_ERROR))
-    state1.ħ == state2.ħ || throw(DimensionMismatch(HBAR_ERROR))
+    state1.ħ == state2.ħ || throw(ArgumentError(HBAR_ERROR))
     mean, covar = _tensor(state1, state2)
     return GaussianState(state1.basis ⊕ state2.basis, mean, covar; ħ = state1.ħ)
 end

--- a/src/states.jl
+++ b/src/states.jl
@@ -446,12 +446,14 @@ covariance: 4×4 Matrix{Float64}:
 """
 function tensor(::Type{Tm}, ::Type{Tc}, state1::GaussianState, state2::GaussianState) where {Tm,Tc}
     typeof(state1.basis) == typeof(state2.basis) || throw(ArgumentError(SYMPLECTIC_ERROR))
+    state1.ħ == state2.ħ || throw(DimensionMismatch(HBAR_ERROR))
     mean, covar = _tensor(state1, state2)
     return GaussianState(state1.basis ⊕ state2.basis, Tm(mean), Tc(covar))
 end
 tensor(::Type{T}, state1::GaussianState, state2::GaussianState) where {T} = tensor(T, T, state1, state2)
 function tensor(state1::GaussianState, state2::GaussianState)
     typeof(state1.basis) == typeof(state2.basis) || throw(ArgumentError(SYMPLECTIC_ERROR))
+    state1.ħ == state2.ħ || throw(DimensionMismatch(HBAR_ERROR))
     mean, covar = _tensor(state1, state2)
     return GaussianState(state1.basis ⊕ state2.basis, mean, covar)
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -104,7 +104,7 @@ end
 
 function Base.:(*)(op::GaussianUnitary, state::GaussianState)
     op.basis == state.basis || throw(DimensionMismatch(ACTION_ERROR))
-    op.ħ == state.ħ || throw(DimensionMismatch(HBAR_ERROR))
+    op.ħ == state.ħ || throw(ArgumentError(HBAR_ERROR))
     d, S, = op.disp, op.symplectic
     mean′ = S * state.mean .+ d
     covar′ = S * state.covar * transpose(S)
@@ -117,7 +117,7 @@ In-place application of a Gaussian unitary `op` on a Gaussian state `state`.
 """
 function apply!(state::GaussianState, op::GaussianUnitary)
     op.basis == state.basis || throw(DimensionMismatch(ACTION_ERROR))
-    op.ħ == state.ħ || throw(DimensionMismatch(HBAR_ERROR))
+    op.ħ == state.ħ || throw(ArgumentError(HBAR_ERROR))
     d, S = op.disp, op.symplectic
     state.mean .= S * state.mean .+ d
     state.covar .= S * state.covar * transpose(S)
@@ -201,7 +201,7 @@ end
 
 function Base.:(*)(op::GaussianChannel, state::GaussianState)
     op.basis == state.basis || throw(DimensionMismatch(ACTION_ERROR))
-    op.ħ == state.ħ || throw(DimensionMismatch(HBAR_ERROR))
+    op.ħ == state.ħ || throw(ArgumentError(HBAR_ERROR))
     d, T, N = op.disp, op.transform, op.noise
     mean′ = T * state.mean .+ d
     covar′ = T * state.covar * transpose(T) .+ N
@@ -214,7 +214,7 @@ In-place application of a Gaussian channel `op` on a Gaussian state `state`.
 """
 function apply!(state::GaussianState, op::GaussianChannel)
     op.basis == state.basis || throw(DimensionMismatch(ACTION_ERROR))
-    op.ħ == state.ħ || throw(DimensionMismatch(HBAR_ERROR))
+    op.ħ == state.ħ || throw(ArgumentError(HBAR_ERROR))
     d, T, N = op.disp, op.transform, op.noise
     state.mean .= T * state.mean .+ d
     state.covar .= T * state.covar * transpose(T) .+ N

--- a/src/types.jl
+++ b/src/types.jl
@@ -33,8 +33,8 @@ covariance: 2×2 Matrix{Float64}:
     end
 end
 
-Base.:(==)(x::GaussianState, y::GaussianState) = x.basis == y.basis && x.mean == y.mean && x.covar == y.covar
-Base.isapprox(x::GaussianState, y::GaussianState; kwargs...) = x.basis == y.basis && isapprox(x.mean, y.mean; kwargs...) && isapprox(x.covar, y.covar; kwargs...)
+Base.:(==)(x::GaussianState, y::GaussianState) = x.basis == y.basis && x.mean == y.mean && x.covar == y.covar && x.ħ == y.h
+Base.isapprox(x::GaussianState, y::GaussianState; kwargs...) = x.basis == y.basis && isapprox(x.mean, y.mean; kwargs...) && isapprox(x.covar, y.covar; kwargs...) && x.ħ == y.h
 function Base.show(io::IO, mime::MIME"text/plain", x::GaussianState)
     Base.summary(io, x)
     print(io, "\n  symplectic basis: ")
@@ -90,8 +90,8 @@ symplectic: 2×2 Matrix{Float64}:
     end
 end
 
-Base.:(==)(x::GaussianUnitary, y::GaussianUnitary) = x.basis == y.basis && x.disp == y.disp && x.symplectic == y.symplectic
-Base.isapprox(x::GaussianUnitary, y::GaussianUnitary; kwargs...) = x.basis == y.basis && isapprox(x.disp, y.disp; kwargs...) && isapprox(x.symplectic, y.symplectic; kwargs...)
+Base.:(==)(x::GaussianUnitary, y::GaussianUnitary) = x.basis == y.basis && x.disp == y.disp && x.symplectic == y.symplectic && x.ħ == y.h
+Base.isapprox(x::GaussianUnitary, y::GaussianUnitary; kwargs...) = x.basis == y.basis && isapprox(x.disp, y.disp; kwargs...) && isapprox(x.symplectic, y.symplectic; kwargs...) && x.ħ == y.h
 function Base.show(io::IO, mime::MIME"text/plain", x::GaussianUnitary)
     Base.summary(io, x)
     print(io, "\n  symplectic basis: ")
@@ -108,7 +108,7 @@ function Base.:(*)(op::GaussianUnitary, state::GaussianState)
     d, S, = op.disp, op.symplectic
     mean′ = S * state.mean .+ d
     covar′ = S * state.covar * transpose(S)
-    return GaussianState(state.basis, mean′, covar′)
+    return GaussianState(state.basis, mean′, covar′; ħ = state.ħ)
 end
 """
     apply!(state::GaussianState, op::GaussianUnitary)
@@ -180,8 +180,8 @@ noise: 2×2 Matrix{Float64}:
     end
 end
 
-Base.:(==)(x::GaussianChannel, y::GaussianChannel) = x.basis == y.basis && x.disp == y.disp && x.transform == y.transform && x.noise == y.noise
-Base.isapprox(x::GaussianChannel, y::GaussianChannel; kwargs...) = x.basis == y.basis && isapprox(x.disp, y.disp; kwargs...) && isapprox(x.transform, y.transform; kwargs...) && isapprox(x.noise, y.noise; kwargs...)
+Base.:(==)(x::GaussianChannel, y::GaussianChannel) = x.basis == y.basis && x.disp == y.disp && x.transform == y.transform && x.noise == y.noise && x.ħ == y.h
+Base.isapprox(x::GaussianChannel, y::GaussianChannel; kwargs...) = x.basis == y.basis && isapprox(x.disp, y.disp; kwargs...) && isapprox(x.transform, y.transform; kwargs...) && isapprox(x.noise, y.noise; kwargs...) && x.ħ == y.h
 function Base.show(io::IO, mime::MIME"text/plain", x::GaussianChannel)
     Base.summary(io, x)
     print(io, "\n  symplectic basis: ")
@@ -210,7 +210,7 @@ function Base.:(*)(op::GaussianChannel, state::GaussianState)
     d, T, N = op.disp, op.transform, op.noise
     mean′ = T * state.mean .+ d
     covar′ = T * state.covar * transpose(T) .+ N
-    return GaussianState(state.basis, mean′, covar′)
+    return GaussianState(state.basis, mean′, covar′; ħ = state.ħ)
 end
 """
     apply!(state::GaussianState, op::GaussianChannel)

--- a/src/types.jl
+++ b/src/types.jl
@@ -15,8 +15,8 @@ julia> coherentstate(QuadPairBasis(1), 1.0+im)
 GaussianState for 1 mode.
   symplectic basis: QuadPairBasis
 mean: 2-element Vector{Float64}:
- 1.4142135623730951
- 1.4142135623730951
+ 2.0
+ 2.0
 covariance: 2×2 Matrix{Float64}:
  1.0  0.0
  0.0  1.0
@@ -33,8 +33,8 @@ covariance: 2×2 Matrix{Float64}:
     end
 end
 
-Base.:(==)(x::GaussianState, y::GaussianState) = x.basis == y.basis && x.mean == y.mean && x.covar == y.covar && x.ħ == y.h
-Base.isapprox(x::GaussianState, y::GaussianState; kwargs...) = x.basis == y.basis && isapprox(x.mean, y.mean; kwargs...) && isapprox(x.covar, y.covar; kwargs...) && x.ħ == y.h
+Base.:(==)(x::GaussianState, y::GaussianState) = x.basis == y.basis && x.mean == y.mean && x.covar == y.covar && x.ħ == y.ħ
+Base.isapprox(x::GaussianState, y::GaussianState; kwargs...) = x.basis == y.basis && isapprox(x.mean, y.mean; kwargs...) && isapprox(x.covar, y.covar; kwargs...) && x.ħ == y.ħ
 function Base.show(io::IO, mime::MIME"text/plain", x::GaussianState)
     Base.summary(io, x)
     print(io, "\n  symplectic basis: ")
@@ -72,8 +72,8 @@ julia> displace(QuadPairBasis(1), 1.0+im)
 GaussianUnitary for 1 mode.
   symplectic basis: QuadPairBasis
 displacement: 2-element Vector{Float64}:
- 1.4142135623730951
- 1.4142135623730951
+ 2.0
+ 2.0
 symplectic: 2×2 Matrix{Float64}:
  1.0  0.0
  0.0  1.0
@@ -90,8 +90,8 @@ symplectic: 2×2 Matrix{Float64}:
     end
 end
 
-Base.:(==)(x::GaussianUnitary, y::GaussianUnitary) = x.basis == y.basis && x.disp == y.disp && x.symplectic == y.symplectic && x.ħ == y.h
-Base.isapprox(x::GaussianUnitary, y::GaussianUnitary; kwargs...) = x.basis == y.basis && isapprox(x.disp, y.disp; kwargs...) && isapprox(x.symplectic, y.symplectic; kwargs...) && x.ħ == y.h
+Base.:(==)(x::GaussianUnitary, y::GaussianUnitary) = x.basis == y.basis && x.disp == y.disp && x.symplectic == y.symplectic && x.ħ == y.ħ
+Base.isapprox(x::GaussianUnitary, y::GaussianUnitary; kwargs...) = x.basis == y.basis && isapprox(x.disp, y.disp; kwargs...) && isapprox(x.symplectic, y.symplectic; kwargs...) && x.ħ == y.ħ
 function Base.show(io::IO, mime::MIME"text/plain", x::GaussianUnitary)
     Base.summary(io, x)
     print(io, "\n  symplectic basis: ")
@@ -137,17 +137,12 @@ Defines a Gaussian channel for an N-mode bosonic system over a 2N-dimensional ph
 
 ## Mathematical description of a Gaussian channel
 
-An ``N``-mode Gaussian channel, ``G(\\mathbf{d}, \\mathbf{T}, \\mathbf{N})``, is an
-operator characterized by a displacement vector ``\\mathbf{d}`` of length ``2N``, as well as
-a transformation matrix ``\\mathbf{T}`` and noise matrix ``\\mathbf{N}`` of size ``2N\\times 2N``,
+An `N`-mode Gaussian channel is an
+operator characterized by a displacement vector `d` of length `2N`, as well as
+a transformation matrix `T` and noise matrix `N` of size `2N x 2N`,
 such that its action on a Gaussian state results in a Gaussian state. More specifically, a Gaussian
-channel action on a Gaussian state ``\\hat{\\rho}(\\mathbf{\\bar{x}}, \\mathbf{V})`` is
-described by its maps on the statistical moments of the Gaussian state:
-
-```math
-\\mathbf{\\bar{x}} \\to \\mathbf{T} \\mathbf{\\bar{x}} + \\mathbf{d}, \\quad
-\\mathbf{V} \\to \\mathbf{T} \\mathbf{V} \\mathbf{T}^{\\text{T}} + \\mathbf{N}.
-```
+channel action on a Gaussian state is described by its maps on
+the statistical moments `x̄` and `V` of the Gaussian state: `x̄ → Tx̄ + d` and `V → TVTᵀ + N`.
 
 ## Example
 
@@ -158,8 +153,8 @@ julia> displace(QuadPairBasis(1), 1.0+im, noise)
 GaussianChannel for 1 mode.
   symplectic basis: QuadPairBasis
 displacement: 2-element Vector{Float64}:
- 1.4142135623730951
- 1.4142135623730951
+ 2.0
+ 2.0
 transform: 2×2 Matrix{Float64}:
  1.0  0.0
  0.0  1.0
@@ -180,8 +175,8 @@ noise: 2×2 Matrix{Float64}:
     end
 end
 
-Base.:(==)(x::GaussianChannel, y::GaussianChannel) = x.basis == y.basis && x.disp == y.disp && x.transform == y.transform && x.noise == y.noise && x.ħ == y.h
-Base.isapprox(x::GaussianChannel, y::GaussianChannel; kwargs...) = x.basis == y.basis && isapprox(x.disp, y.disp; kwargs...) && isapprox(x.transform, y.transform; kwargs...) && isapprox(x.noise, y.noise; kwargs...) && x.ħ == y.h
+Base.:(==)(x::GaussianChannel, y::GaussianChannel) = x.basis == y.basis && x.disp == y.disp && x.transform == y.transform && x.noise == y.noise && x.ħ == y.ħ
+Base.isapprox(x::GaussianChannel, y::GaussianChannel; kwargs...) = x.basis == y.basis && isapprox(x.disp, y.disp; kwargs...) && isapprox(x.transform, y.transform; kwargs...) && isapprox(x.noise, y.noise; kwargs...) && x.ħ == y.ħ
 function Base.show(io::IO, mime::MIME"text/plain", x::GaussianChannel)
     Base.summary(io, x)
     print(io, "\n  symplectic basis: ")
@@ -242,8 +237,8 @@ julia> op = displace(basis, 1.0-im)
 GaussianUnitary for 1 mode.
   symplectic basis: QuadPairBasis
 displacement: 2-element Vector{Float64}:
-  1.4142135623730951
- -1.4142135623730951
+  2.0
+ -2.0
 symplectic: 2×2 Matrix{Float64}:
  1.0  0.0
  0.0  1.0

--- a/src/types.jl
+++ b/src/types.jl
@@ -104,6 +104,7 @@ end
 
 function Base.:(*)(op::GaussianUnitary, state::GaussianState)
     op.basis == state.basis || throw(DimensionMismatch(ACTION_ERROR))
+    op.ħ == state.ħ || throw(DimensionMismatch(HBAR_ERROR))
     d, S, = op.disp, op.symplectic
     mean′ = S * state.mean .+ d
     covar′ = S * state.covar * transpose(S)
@@ -116,6 +117,7 @@ In-place application of a Gaussian unitary `op` on a Gaussian state `state`.
 """
 function apply!(state::GaussianState, op::GaussianUnitary)
     op.basis == state.basis || throw(DimensionMismatch(ACTION_ERROR))
+    op.ħ == state.ħ || throw(DimensionMismatch(HBAR_ERROR))
     d, S = op.disp, op.symplectic
     state.mean .= S * state.mean .+ d
     state.covar .= S * state.covar * transpose(S)
@@ -203,7 +205,8 @@ function Base.summary(io::IO, x::Union{GaussianState,GaussianUnitary,GaussianCha
 end
 
 function Base.:(*)(op::GaussianChannel, state::GaussianState)
-    op.basis == state.basis && op.ħ == state.ħ || throw(DimensionMismatch(ACTION_ERROR))
+    op.basis == state.basis || throw(DimensionMismatch(ACTION_ERROR))
+    op.ħ == state.ħ || throw(DimensionMismatch(HBAR_ERROR))
     d, T, N = op.disp, op.transform, op.noise
     mean′ = T * state.mean .+ d
     covar′ = T * state.covar * transpose(T) .+ N
@@ -215,7 +218,8 @@ end
 In-place application of a Gaussian channel `op` on a Gaussian state `state`.
 """
 function apply!(state::GaussianState, op::GaussianChannel)
-    op.basis == state.basis && op.ħ == state.ħ || throw(DimensionMismatch(ACTION_ERROR))
+    op.basis == state.basis || throw(DimensionMismatch(ACTION_ERROR))
+    op.ħ == state.ħ || throw(DimensionMismatch(HBAR_ERROR))
     d, T, N = op.disp, op.transform, op.noise
     state.mean .= T * state.mean .+ d
     state.covar .= T * state.covar * transpose(T) .+ N

--- a/src/unitaries.jl
+++ b/src/unitaries.jl
@@ -24,8 +24,8 @@ julia> displace(QuadPairBasis(1), 1.0+im)
 GaussianUnitary for 1 mode.
   symplectic basis: QuadPairBasis
 displacement: 2-element Vector{Float64}:
- 1.4142135623730951
- 1.4142135623730951
+ 2.0
+ 2.0
 symplectic: 2×2 Matrix{Float64}:
  1.0  0.0
  0.0  1.0
@@ -653,10 +653,10 @@ julia> op = displace(QuadBlockBasis(2), 1.0-im)
 GaussianUnitary for 2 modes.
   symplectic basis: QuadBlockBasis
 displacement: 4-element Vector{Float64}:
-  1.4142135623730951
-  1.4142135623730951
- -1.4142135623730951
- -1.4142135623730951
+  2.0
+  2.0
+ -2.0
+ -2.0
 symplectic: 4×4 Matrix{Float64}:
  1.0  0.0  0.0  0.0
  0.0  1.0  0.0  0.0
@@ -667,10 +667,10 @@ julia> changebasis(QuadPairBasis, op)
 GaussianUnitary for 2 modes.
   symplectic basis: QuadPairBasis
 displacement: 4-element Vector{Float64}:
-  1.4142135623730951
- -1.4142135623730951
-  1.4142135623730951
- -1.4142135623730951
+  2.0
+ -2.0
+  2.0
+ -2.0
 symplectic: 4×4 Matrix{Float64}:
  1.0  0.0  0.0  0.0
  0.0  1.0  0.0  0.0

--- a/src/unitaries.jl
+++ b/src/unitaries.jl
@@ -42,8 +42,10 @@ function displace(basis::SymplecticBasis{N}, alpha::A; ħ = 2) where {N<:Int,A}
 end
 function _displace(basis::QuadPairBasis{N}, alpha::A; ħ = 2) where {N<:Int,A<:Number}
     nmodes = basis.nmodes
+    Rt = real(eltype(A))
     disp = repeat([sqrt(2*ħ) * real(alpha), sqrt(2*ħ) * imag(alpha)], nmodes)
-    symplectic = Matrix{real(A)}(I, 2*nmodes, 2*nmodes)
+    
+    symplectic = Matrix{Rt}(I, 2*nmodes, 2*nmodes)
     return disp, symplectic
 end
 function _displace(basis::QuadPairBasis{N}, alpha::A; ħ = 2) where {N<:Int,A<:Vector}
@@ -55,8 +57,9 @@ function _displace(basis::QuadPairBasis{N}, alpha::A; ħ = 2) where {N<:Int,A<:V
 end
 function _displace(basis::QuadBlockBasis{N}, alpha::A; ħ = 2) where {N<:Int,A<:Number}
     nmodes = basis.nmodes
+    Rt = real(eltype(A))
     disp = repeat([sqrt(2*ħ) * real(alpha), sqrt(2*ħ) * imag(alpha)], inner = nmodes)
-    symplectic = Matrix{real(A)}(I, 2*nmodes, 2*nmodes)
+    symplectic = Matrix{Rt}(I, 2*nmodes, 2*nmodes)
     return disp, symplectic
 end
 function _displace(basis::QuadBlockBasis{N}, alpha::A; ħ = 2) where {N<:Int,A<:Vector}
@@ -111,6 +114,7 @@ function squeeze(basis::SymplecticBasis{N}, r::R, theta::R; ħ = 2) where {N<:In
 end
 function _squeeze(basis::QuadPairBasis{N}, r::R, theta::R) where {N<:Int,R<:Real}
     nmodes = basis.nmodes
+    Rt = real(eltype(R))
     disp = zeros(R, 2*nmodes)
     cr, sr = cosh(r), sinh(r)
     ct, st = cos(theta), sin(theta)
@@ -140,6 +144,7 @@ function _squeeze(basis::QuadPairBasis{N}, r::R, theta::R) where {N<:Int,R<:Vect
 end
 function _squeeze(basis::QuadBlockBasis{N}, r::R, theta::R) where {N<:Int,R<:Real}
     nmodes = basis.nmodes
+    Rt = real(eltype(R))
     disp = zeros(R, 2*nmodes)
     cr, sr = cosh(r), sinh(r)
     ct, st = cos(theta), sin(theta)

--- a/src/unitaries.jl
+++ b/src/unitaries.jl
@@ -543,14 +543,14 @@ function tensor(::Type{Td}, ::Type{Ts}, op1::GaussianUnitary, op2::GaussianUnita
     typeof(op1.basis) == typeof(op2.basis) || throw(ArgumentError(SYMPLECTIC_ERROR))
     op1.ħ == op2.ħ || throw(DimensionMismatch(HBAR_ERROR))
     disp, symplectic = _tensor(op1, op2)
-    return GaussianUnitary(op1.basis ⊕ op2.basis, Td(disp), Ts(symplectic))
+    return GaussianUnitary(op1.basis ⊕ op2.basis, Td(disp), Ts(symplectic); ħ = op1.ħ)
 end
 tensor(::Type{T}, op1::GaussianUnitary, op2::GaussianUnitary) where {T} = tensor(T, T, op1, op2)
 function tensor(op1::GaussianUnitary, op2::GaussianUnitary)
     typeof(op1.basis) == typeof(op2.basis) || throw(ArgumentError(SYMPLECTIC_ERROR))
     op1.ħ == op2.ħ || throw(DimensionMismatch(HBAR_ERROR))
     disp, symplectic = _tensor(op1, op2)
-    return GaussianUnitary(op1.basis ⊕ op2.basis, disp, symplectic)
+    return GaussianUnitary(op1.basis ⊕ op2.basis, disp, symplectic; ħ = op1.ħ)
 end
 function _tensor(op1::GaussianUnitary{B1,D1,S1}, op2::GaussianUnitary{B2,D2,S2}) where {B1<:QuadPairBasis,B2<:QuadPairBasis,D1,D2,S1,S2}
     basis1, basis2 = op1.basis, op2.basis
@@ -690,7 +690,7 @@ function changebasis(::Type{B1}, op::GaussianUnitary{B2,D,S}) where {B1<:QuadBlo
     T = typeof(T) == S ? T : S(T)
     disp = T * op.disp
     symp = T * op.symplectic * transpose(T)
-    return GaussianUnitary(B1(nmodes), disp, symp)
+    return GaussianUnitary(B1(nmodes), disp, symp; ħ = op.ħ)
 end
 function changebasis(::Type{B1}, op::GaussianUnitary{B2,D,S}) where {B1<:QuadPairBasis,B2<:QuadBlockBasis,D,S}
     basis = op.basis
@@ -704,7 +704,7 @@ function changebasis(::Type{B1}, op::GaussianUnitary{B2,D,S}) where {B1<:QuadPai
     T = typeof(T) == S ? T : S(T)
     disp = T * op.disp
     symp = T * op.symplectic * transpose(T)
-    return GaussianUnitary(B1(nmodes), disp, symp)
+    return GaussianUnitary(B1(nmodes), disp, symp; ħ = op.ħ)
 end
 changebasis(::Type{<:QuadBlockBasis}, op::GaussianUnitary{<:QuadBlockBasis,D,S}) where {D,S} = op
 changebasis(::Type{<:QuadPairBasis}, op::GaussianUnitary{<:QuadPairBasis,D,S}) where {D,S} = op

--- a/src/unitaries.jl
+++ b/src/unitaries.jl
@@ -81,9 +81,8 @@ with `noise`.
 ## Mathematical description of a squeezing operator
 
 A squeeze operator `S(r, θ)` is defined by the operation
-`S(r, θ)|0⟩ = |r, θ⟩``, where ``r`` and ``θ``
-are the real amplitude and phase parameters, respectively. The operator 
-``S(r, θ)`` is characterized by 
+`S(r, θ)|0⟩ = |r, θ⟩`, where `r` and `θ` are the real amplitude and phase parameters, 
+respectively. The operator `S(r, θ)` is characterized by 
 the zero displacement vector and symplectic
 matrix `cosh(r)I - sinh(r)R(θ)`, where `R(θ)` is the rotation matrix.
 
@@ -329,12 +328,11 @@ with `noise`.
 ## Mathematical description of a phase shift operator
 
 A phase shift operator is defined by the operation
-`U(θ) = exp(-iθâᵗâ)``, where `θ` is
+`U(θ) = exp(-iθâᵗâ)`, where `θ` is
 the phase parameter, and `âᵗ` and `â` are the raising
 and lowering operators, respectively. The operator `U(θ)` is characterized by 
 the zero displacement vector and symplectic
 matrix `[cos(θ) sin(θ); -sin(θ) cos(θ)]`.
-```
 
 ## Example
 

--- a/src/unitaries.jl
+++ b/src/unitaries.jl
@@ -541,11 +541,14 @@ end
 
 function tensor(::Type{Td}, ::Type{Ts}, op1::GaussianUnitary, op2::GaussianUnitary) where {Td,Ts}
     typeof(op1.basis) == typeof(op2.basis) || throw(ArgumentError(SYMPLECTIC_ERROR))
+    op1.ħ == op2.ħ || throw(DimensionMismatch(HBAR_ERROR))
     disp, symplectic = _tensor(op1, op2)
     return GaussianUnitary(op1.basis ⊕ op2.basis, Td(disp), Ts(symplectic))
 end
 tensor(::Type{T}, op1::GaussianUnitary, op2::GaussianUnitary) where {T} = tensor(T, T, op1, op2)
 function tensor(op1::GaussianUnitary, op2::GaussianUnitary)
+    typeof(op1.basis) == typeof(op2.basis) || throw(ArgumentError(SYMPLECTIC_ERROR))
+    op1.ħ == op2.ħ || throw(DimensionMismatch(HBAR_ERROR))
     disp, symplectic = _tensor(op1, op2)
     return GaussianUnitary(op1.basis ⊕ op2.basis, disp, symplectic)
 end

--- a/src/unitaries.jl
+++ b/src/unitaries.jl
@@ -539,14 +539,14 @@ end
 
 function tensor(::Type{Td}, ::Type{Ts}, op1::GaussianUnitary, op2::GaussianUnitary) where {Td,Ts}
     typeof(op1.basis) == typeof(op2.basis) || throw(ArgumentError(SYMPLECTIC_ERROR))
-    op1.ħ == op2.ħ || throw(DimensionMismatch(HBAR_ERROR))
+    op1.ħ == op2.ħ || throw(ArgumentError(HBAR_ERROR))
     disp, symplectic = _tensor(op1, op2)
     return GaussianUnitary(op1.basis ⊕ op2.basis, Td(disp), Ts(symplectic); ħ = op1.ħ)
 end
 tensor(::Type{T}, op1::GaussianUnitary, op2::GaussianUnitary) where {T} = tensor(T, T, op1, op2)
 function tensor(op1::GaussianUnitary, op2::GaussianUnitary)
     typeof(op1.basis) == typeof(op2.basis) || throw(ArgumentError(SYMPLECTIC_ERROR))
-    op1.ħ == op2.ħ || throw(DimensionMismatch(HBAR_ERROR))
+    op1.ħ == op2.ħ || throw(ArgumentError(HBAR_ERROR))
     disp, symplectic = _tensor(op1, op2)
     return GaussianUnitary(op1.basis ⊕ op2.basis, disp, symplectic; ħ = op1.ħ)
 end

--- a/src/unitaries.jl
+++ b/src/unitaries.jl
@@ -44,7 +44,6 @@ function _displace(basis::QuadPairBasis{N}, alpha::A; ħ = 2) where {N<:Int,A<:N
     nmodes = basis.nmodes
     Rt = real(eltype(A))
     disp = repeat([sqrt(2*ħ) * real(alpha), sqrt(2*ħ) * imag(alpha)], nmodes)
-    
     symplectic = Matrix{Rt}(I, 2*nmodes, 2*nmodes)
     return disp, symplectic
 end

--- a/test/test_channels.jl
+++ b/test/test_channels.jl
@@ -30,6 +30,7 @@
         @test displace(Array, qpairbasis, alpha, noise) isa GaussianChannel
         @test displace(qblockbasis, alpha, T*noise*transpose(T)) == changebasis(QuadBlockBasis, op_pair)
         @test displace(qblockbasis, alphas, T*noise*transpose(T)) == changebasis(QuadBlockBasis, displace(qpairbasis, alphas, noise))
+        @test op_pair.ħ == 2 && op_block.ħ == 2
     end
 
     @testset "squeeze operator" begin
@@ -42,39 +43,37 @@
         @test squeeze(Array, qpairbasis, r, theta, noise) isa GaussianChannel
         @test squeeze(qblockbasis, r, theta, T*noise*transpose(T)) == changebasis(QuadBlockBasis, op_pair)
         @test squeeze(qblockbasis, rs, thetas, T*noise*transpose(T)) == changebasis(QuadBlockBasis, squeeze(qpairbasis, rs, thetas, noise))
+        @test op_pair.ħ == 2 && op_block.ħ == 2
     end
 
     @testset "two-mode squeeze operator" begin
         r, theta = rand(Float64), rand(Float64)
         rs, thetas = rand(Float64, nmodes), rand(Float64, nmodes)
-        op = twosqueeze(2*qpairbasis, r, theta, noise_ds)
-        @test op isa GaussianChannel
-        @test twosqueeze(SVector{4*nmodes}, SMatrix{4*nmodes,4*nmodes}, 2*qpairbasis, r, theta, noise_ds) isa GaussianChannel
-        @test twosqueeze(Array, 2*qpairbasis, r, theta, noise_ds) isa GaussianChannel
+        op, op_array, op_static = twosqueeze(2*qpairbasis, r, theta, noise_ds), twosqueeze(Array, 2*qpairbasis, r, theta, noise_ds), twosqueeze(SVector{4*nmodes}, SMatrix{4*nmodes,4*nmodes}, 2*qpairbasis, r, theta, noise_ds)
+        @test op isa GaussianChannel && op_array isa GaussianChannel && op_static isa GaussianChannel
         @test twosqueeze(2*qblockbasis, r, theta, T_ds*noise_ds*transpose(T_ds)) == changebasis(QuadBlockBasis, op)
         @test twosqueeze(2*qblockbasis, rs, thetas, T_ds*noise_ds*transpose(T_ds)) == changebasis(QuadBlockBasis, twosqueeze(2*qpairbasis, rs, thetas, noise_ds))
+        @test op.ħ == 2 && op_array.ħ == 2 && op_static.ħ == 2
     end
 
     @testset "phase-shift operator" begin
         theta = rand(Float64)
         thetas = rand(Float64, nmodes)
-        op = phaseshift(qpairbasis, theta, noise)
-        @test op isa GaussianChannel
-        @test phaseshift(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis, theta, noise) isa GaussianChannel
-        @test phaseshift(Array, qpairbasis, theta, noise) isa GaussianChannel
+        op, op_array, op_static = phaseshift(qpairbasis, theta, noise), phaseshift(Array, qpairbasis, theta, noise), phaseshift(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis, theta, noise)
+        @test op isa GaussianChannel && op_array isa GaussianChannel && op_static isa GaussianChannel
         @test phaseshift(qblockbasis, theta, T*noise*transpose(T)) == changebasis(QuadBlockBasis, op)
         @test phaseshift(qblockbasis, thetas, T*noise*transpose(T)) == changebasis(QuadBlockBasis, phaseshift(qpairbasis, thetas, noise))
+        @test op.ħ == 2 && op_array.ħ == 2 && op_static.ħ == 2
     end
 
     @testset "beamsplitter operator" begin
         theta = rand(Float64)
         thetas = rand(Float64, nmodes)
-        op = beamsplitter(2*qpairbasis, theta, noise_ds)
-        @test op isa GaussianChannel
-        @test beamsplitter(SVector{4*nmodes}, SMatrix{4*nmodes,4*nmodes}, 2*qpairbasis, theta, noise_ds) isa GaussianChannel
-        @test beamsplitter(Array, 2*qpairbasis, theta, noise_ds) isa GaussianChannel
+        op, op_array, op_static = beamsplitter(2*qpairbasis, theta, noise_ds), beamsplitter(Array, 2*qpairbasis, theta, noise_ds), beamsplitter(SVector{4*nmodes}, SMatrix{4*nmodes,4*nmodes}, 2*qpairbasis, theta, noise_ds)
+        @test op isa GaussianChannel && op_array isa GaussianChannel && op_static isa GaussianChannel
         @test beamsplitter(2*qblockbasis, theta, T_ds*noise_ds*transpose(T_ds)) == changebasis(QuadBlockBasis, op)
         @test beamsplitter(2*qblockbasis, thetas, T_ds*noise_ds*transpose(T_ds)) == changebasis(QuadBlockBasis, beamsplitter(2*qpairbasis, thetas, noise_ds))
+        @test op.ħ == 2 && op_array.ħ == 2 && op_static.ħ == 2
     end
 
     @testset "attenuator channel" begin
@@ -92,6 +91,7 @@
         @test attenuator(qblockbasis, theta, n) == changebasis(QuadBlockBasis, op_pair)
         @test attenuator(qblockbasis, thetas, ns) == changebasis(QuadBlockBasis, attenuator(qpairbasis, thetas, ns))
         @test isgaussian(op_pair, atol = 1e-4)
+        @test op_pair.ħ == 2 && op_block.ħ == 2
     end
 
     @testset "amplifier channel" begin
@@ -109,6 +109,7 @@
         @test amplifier(qblockbasis, r, n) == changebasis(QuadBlockBasis, op_pair)
         @test amplifier(qblockbasis, rs, ns) == changebasis(QuadBlockBasis, amplifier(qpairbasis, rs, ns))
         @test isgaussian(op_pair, atol = 1e-4)
+        @test op_pair.ħ == 2 && op_block.ħ == 2
     end
     
     @testset "tensor products" begin

--- a/test/test_randoms.jl
+++ b/test/test_randoms.jl
@@ -36,7 +36,7 @@
     end
 
     @testset "random states" begin
-        nmodes = rand(1:5)
+        nmodes, ħ = rand(1:5), rand(1:5)
         qpairbasis = QuadPairBasis(nmodes)
         qblockbasis = QuadBlockBasis(nmodes)
         rs_pair = randstate(qpairbasis)
@@ -44,11 +44,12 @@
         rc = randchannel(qpairbasis)
         @test rc isa GaussianChannel
         @test rc * rs_pair isa GaussianState
+        @test rs_pair.ħ == 2 && rs_block.ħ == 2
         @test isgaussian(rs_pair, atol = 1e-5)
         @test isgaussian(rs_block, atol = 1e-5)
 
-        rspure_pair = randstate(qpairbasis, pure = true)
-        rspure_block = randstate(qblockbasis, pure = true)
+        rspure_pair = randstate(qpairbasis, pure = true, ħ = ħ)
+        rspure_block = randstate(qblockbasis, pure = true, ħ = ħ)
         @test isgaussian(rspure_pair, atol = 1e-5)
         @test isapprox(purity(rspure_pair), 1.0, atol = 1e-5)
         @test isgaussian(rspure_block, atol = 1e-5)
@@ -57,6 +58,7 @@
         rs_array = randstate(Array, qpairbasis)
         rc_array = randchannel(Array, qpairbasis)
         @test rc_array isa GaussianChannel
+        @test rc_array.ħ == 2
         @test rc_array * rs_array isa GaussianState
         @test isgaussian(rs_array, atol = 1e-5)
 
@@ -67,6 +69,7 @@
         rs_static = randstate(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis)
         rc_static = randchannel(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis)
         @test rc_static isa GaussianChannel
+        @test rs_static isa GaussianState
         @test rc_static * rs_static isa GaussianState
         @test isgaussian(rs_static, atol = 1e-5)
 
@@ -76,17 +79,19 @@
     end
 
     @testset "random unitaries" begin
-        nmodes = rand(1:5)
+        nmodes, ħ = rand(1:5), rand(1:5)
         qpairbasis = QuadPairBasis(nmodes)
         qblockbasis = QuadBlockBasis(nmodes)
-        ru = randunitary(qpairbasis)
+        ru = randunitary(qpairbasis, ħ = ħ)
         @test isgaussian(ru, atol = 1e-5)
 
         rupassive = randunitary(qpairbasis, passive = true)
+        @test rupassive.ħ == 2
         @test isapprox(rupassive.symplectic', inv(rupassive.symplectic), atol = 1e-5)
         @test isgaussian(rupassive, atol = 1e-5)
 
         ru_array = randunitary(Array, qpairbasis)
+        @test ru_array.ħ == 2
         @test isgaussian(ru_array, atol = 1e-5)
 
         rupassive_array = randunitary(qpairbasis, passive = true)
@@ -94,6 +99,7 @@
         @test isgaussian(rupassive_array, atol = 1e-5)
 
         ru_static = randunitary(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis)
+        @test ru_static.ħ == 2
         @test isgaussian(ru_static, atol = 1e-5)
 
         rupassive_static = randunitary(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis, passive = true)
@@ -102,16 +108,18 @@
     end
 
     @testset "random channels" begin
-        nmodes = rand(1:5)
+        nmodes, ħ = rand(1:5), rand(1:5)
         qpairbasis = QuadPairBasis(nmodes)
         qblockbasis = QuadBlockBasis(nmodes)
-        rc = randchannel(qpairbasis)
+        rc = randchannel(qpairbasis, ħ = ħ)
         @test isgaussian(rc, atol = 1e-5)
 
         rc_array = randchannel(Array, qpairbasis)
+        @test rc_array.ħ == 2
         @test isgaussian(rc_array, atol = 1e-5)
 
         rc_static = randchannel(SVector{2*nmodes}, SMatrix{2*nmodes, 2*nmodes}, qpairbasis)
+        @test rc_static.ħ == 2
         @test isgaussian(rc_static, atol = 1e-5)
     end
 end

--- a/test/test_states.jl
+++ b/test/test_states.jl
@@ -8,10 +8,10 @@
     qblockbasis = QuadBlockBasis(nmodes)
 
     @testset "vacuum states" begin
-        state = vacuumstate(qpairbasis)
-        @test state isa GaussianState
-        @test vacuumstate(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis) isa GaussianState
+        state, array_state, static_state = vacuumstate(qpairbasis), vacuumstate(Array, qpairbasis), vacuumstate(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis)
+        @test state isa GaussianState && array_state isa GaussianState && static_state isa GaussianState
         @test vacuumstate(qblockbasis) == changebasis(QuadBlockBasis, state)
+        @test state.ħ == 2 && array_state.ħ == 2 && static_state.ħ == 2
     end
 
     @testset "thermal states" begin
@@ -26,6 +26,7 @@
         @test state_pair == changebasis(QuadPairBasis, state_pair) && state_block == changebasis(QuadBlockBasis, state_block)
         @test thermalstate(qblockbasis, ns) == changebasis(QuadBlockBasis, thermalstate(qpairbasis, ns))
         @test isgaussian(state_pair, atol = 1e-4)
+        @test state_pair.ħ == 2 && state_block.ħ == 2
     end
 
     @testset "coherent states" begin
@@ -40,26 +41,28 @@
         @test state_pair == changebasis(QuadPairBasis, state_pair) && state_block == changebasis(QuadBlockBasis, state_block)
         @test coherentstate(qblockbasis, alphas) == changebasis(QuadBlockBasis, coherentstate(qpairbasis, alphas))
         @test isgaussian(state_pair, atol = 1e-4)
+        @test state_pair.ħ == 2 && state_block.ħ == 2
     end
 
     @testset "squeezed states" begin
         r, theta = rand(Float64), rand(Float64)
         rs, thetas = rand(Float64, nmodes), rand(Float64, nmodes)
-        state = squeezedstate(qpairbasis, r, theta)
-        @test state isa GaussianState
-        @test squeezedstate(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis, r, theta) isa GaussianState
+        state, array_state, static_state = squeezedstate(qpairbasis, r, theta), squeezedstate(Array, qpairbasis, r, theta), squeezedstate(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis, r, theta)
+        @test state isa GaussianState && array_state isa GaussianState && static_state isa GaussianState
         @test squeezedstate(qblockbasis, r, theta) == changebasis(QuadBlockBasis, state)
         @test squeezedstate(qblockbasis, rs, thetas) == changebasis(QuadBlockBasis, squeezedstate(qpairbasis, rs, thetas))
+        @test state.ħ == 2 && array_state.ħ == 2 && static_state.ħ == 2
     end
 
     @testset "epr states" begin
         r, theta = rand(Float64), rand(Float64)
         rs, thetas = rand(Float64, nmodes), rand(Float64, nmodes)
-        state = eprstate(2*qpairbasis, r, theta)
-        @test state isa GaussianState
+        state, array_state, static_state = eprstate(2*qpairbasis, r, theta), eprstate(Array, 2*qpairbasis, r, theta), eprstate(SVector{4*nmodes}, SMatrix{4*nmodes,4*nmodes}, 2*qpairbasis, r, theta)
+        @test state isa GaussianState && array_state isa GaussianState && static_state isa GaussianState
         @test eprstate(SVector{4*nmodes}, SMatrix{4*nmodes,4*nmodes}, 2*qpairbasis, r, theta) isa GaussianState
         @test eprstate(2*qblockbasis, r, theta) == changebasis(QuadBlockBasis, state)
         @test eprstate(2*qblockbasis, rs, thetas) == changebasis(QuadBlockBasis, eprstate(2*qpairbasis, rs, thetas))
+        @test state.ħ == 2 && array_state.ħ == 2 && static_state.ħ == 2
     end
 
     @testset "tensor products" begin

--- a/test/test_symbolic_unitaries.jl
+++ b/test/test_symbolic_unitaries.jl
@@ -1,0 +1,96 @@
+@testitem "Symbolic Unitaries" begin
+    using Gabs
+    using Symbolics
+    using StaticArrays
+    using LinearAlgebra: det
+
+    nmodes = rand(1:5)
+    qpairbasis = QuadPairBasis(nmodes)
+    qblockbasis = QuadBlockBasis(nmodes)
+
+    for (name, op_func, factor) in [("squeeze", squeeze, 1), ("two-mode squeeze", twosqueeze, 2)]
+        @testset "Symbolic $name operator" begin
+            @variables r theta
+            op_pair = op_func(factor * qpairbasis, r, theta)
+            op_block = op_func(factor * qblockbasis, r, theta)
+            @test op_pair isa GaussianUnitary && op_block isa GaussianUnitary
+            @test op_func(Array, factor * qpairbasis, r, theta) isa GaussianUnitary
+            @test op_func(SVector{factor * 2 * nmodes}, SMatrix{factor * 2 * nmodes, factor * 2 * nmodes}, factor * qpairbasis, r, theta) isa GaussianUnitary
+            @test isequal(op_func(factor * qblockbasis, r, theta).disp, changebasis(QuadBlockBasis, op_pair).disp)
+            @test isequal(op_func(factor * qblockbasis, r, theta).symplectic, changebasis(QuadBlockBasis, op_pair).symplectic)
+            @variables rs[1:nmodes] thetas[1:nmodes]
+            rs_vec = collect(rs)
+            thetas_vec = collect(thetas)
+            op_pair_arr = op_func(factor * qpairbasis, rs_vec, thetas_vec)
+            op_block_arr = op_func(factor * qblockbasis, rs_vec, thetas_vec)
+            @test op_pair_arr isa GaussianUnitary && op_block_arr isa GaussianUnitary
+            @test op_func(Array, factor * qpairbasis, rs_vec, thetas_vec) isa GaussianUnitary
+            @test op_func(SVector{factor * 2 * nmodes}, SMatrix{factor * 2 * nmodes, factor * 2 * nmodes}, factor * qpairbasis, rs_vec, thetas_vec) isa GaussianUnitary
+            @test isequal(op_func(factor * qblockbasis, rs_vec, thetas_vec).disp, changebasis(QuadBlockBasis, op_pair_arr).disp)
+            @test isequal(op_func(factor * qblockbasis, rs_vec, thetas_vec).symplectic, changebasis(QuadBlockBasis, op_pair_arr).symplectic)
+        end
+    end
+
+    for (name, op_func, factor) in [("phase-shift", phaseshift, 1), ("beamsplitter", beamsplitter, 2),("displace", displace, 1)]
+        @testset "Symbolic $name operator" begin
+            @variables theta
+            op = op_func(factor * qpairbasis, theta)
+            @test op isa GaussianUnitary
+            @test op_func(Array, factor * qpairbasis, theta) isa GaussianUnitary
+            @test op_func(SVector{factor * 2 * nmodes}, SMatrix{factor * 2 * nmodes, factor * 2 * nmodes}, factor * qpairbasis, theta) isa GaussianUnitary
+            @test isequal(op_func(factor * qblockbasis, theta).disp, changebasis(QuadBlockBasis, op).disp)
+            @test isequal(op_func(factor * qblockbasis, theta).symplectic, changebasis(QuadBlockBasis, op).symplectic)
+            @variables thetas[1:nmodes]
+            thetas_vec = vcat([real(thetas[i]) for i in 1:nmodes], [imag(thetas[i]) for i in 1:nmodes])
+            op_arr = op_func(factor * qpairbasis, thetas_vec)
+            op_block_arr = op_func(factor * qblockbasis, thetas_vec)
+            @test op_arr isa GaussianUnitary && op_block_arr isa GaussianUnitary
+            @test op_func(Array, factor * qpairbasis, thetas_vec) isa GaussianUnitary
+            @test op_func(SVector{factor * 2 * nmodes}, SMatrix{factor * 2 * nmodes, factor * 2 * nmodes}, factor * qpairbasis, thetas_vec) isa GaussianUnitary
+            @test isequal(op_func(factor * qblockbasis, thetas_vec).disp, changebasis(QuadBlockBasis, op_arr).disp)
+            @test isequal(op_func(factor * qblockbasis, thetas_vec).symplectic, changebasis(QuadBlockBasis, op_arr).symplectic)
+        end
+    end
+
+    @testset "Symbolic Tensor Products" begin
+        @variables alpha1 alpha2
+        d1, d2 = displace(qpairbasis, alpha1), displace(qpairbasis, alpha2)
+        ds = tensor(d1, d2)
+        @test ds isa GaussianUnitary
+        @test isequal(ds.disp, (d1 ⊗ d2).disp)
+        @test isequal(ds.symplectic, (d1 ⊗ d2).symplectic)
+        @test isapprox(ds, d1 ⊗ d2, atol = 1e-10)
+        @test tensor(SVector{4*nmodes}, SMatrix{4*nmodes, 4*nmodes}, d1, d2) isa GaussianUnitary
+        @variables theta
+        p = phaseshift(qpairbasis, theta)
+        @test isequal(tensor(p, tensor(d1, d2)).disp, (p ⊗ d1 ⊗ d2).disp)
+        @test isequal(tensor(p, tensor(d1, d2)).symplectic, (p ⊗ d1 ⊗ d2).symplectic)
+        p_block = phaseshift(qblockbasis, theta)
+        @variables thetas[1:2*nmodes]
+        p_blocks = phaseshift(2 * qblockbasis, collect(thetas))
+        @test isequal((p_block ⊗ p_block).disp, p_blocks.disp)
+        @test isequal(simplify((p_block ⊗ p_block).symplectic), simplify(substitute(p_blocks.symplectic, Dict(thetas[i] => theta for i in eachindex(thetas)))))
+    end
+
+    @testset "Symbolic actions" begin
+        @variables α1 α2 r theta r1 theta1
+        d = displace(qpairbasis, α1)
+        v = vacuumstate(qpairbasis)
+        s = squeezedstate(qpairbasis, r, theta)
+        c = coherentstate(qpairbasis,α1)
+        @test isequal((d * v).mean, c.mean)
+        @test isequal((d * v).covar, c.covar)
+        @test_broken isequal(apply!(v, d).mean, c.mean)
+        @test_broken isequal(apply!(v, d).covar, c.covar)
+        @test isequal(apply!(s, d).mean, c.mean)
+        d1, d2 = displace(qpairbasis, α1), displace(qpairbasis, α2)
+        v1, v2 = vacuumstate(qpairbasis), vacuumstate(qpairbasis)
+        s1, s2 = squeezedstate(qpairbasis, r, theta), squeezedstate(qpairbasis, r1, theta1)
+        c1, c2 = coherentstate(qpairbasis, α1), coherentstate(qpairbasis, α2)
+        @test simplify(d1 * v1) ≈ simplify(c1)
+        @test isequal(simplify(d1 * v1).mean, simplify(c1).mean)
+        @test isequal(simplify(d1 * v1).covar, simplify(c1).covar)
+        @test isequal(apply!(s1, d1).mean, simplify(c1).mean)
+        @test isequal(apply!(s2, d1).mean, simplify(c1).mean)
+    end
+end

--- a/test/test_throws.jl
+++ b/test/test_throws.jl
@@ -23,4 +23,18 @@
         ts = twosqueeze(2*basis1, rand(), rand())
         @test_throws ArgumentError Makie.heatmap(collect(-3.0:0.25:3.0), collect(-3.0:0.25:3.0), ts)
     end
+
+    @testset "hbar throws" begin
+        rs1, rs2 = randstate(basis1, ħ = 1), randstate(basis1)
+        ru1, ru2 = randunitary(basis1, ħ = 1), randunitary(basis1)
+        rc1, rc2 = randchannel(basis1, ħ = 1), randchannel(basis1)
+        
+        @test_throws ArgumentError ru2 * rs1
+        @test_throws ArgumentError rc1 * rs2
+        @test_throws ArgumentError apply!(rs1, ru2)
+        @test_throws ArgumentError apply!(rs2, rc1)
+        @test_throws ArgumentError rs1 ⊗ rs2
+        @test_throws ArgumentError ru1 ⊗ ru2
+        @test_throws ArgumentError rc1 ⊗ rc2
+    end
 end

--- a/test/test_unitaries.jl
+++ b/test/test_unitaries.jl
@@ -20,6 +20,7 @@
         @test displace(qblockbasis, alphas) == changebasis(QuadBlockBasis, displace(qpairbasis, alphas))
         @test issymplectic(qpairbasis, op_pair.symplectic, atol = 1e-4)
         @test isgaussian(op_pair, atol = 1e-4)
+        @test op_pair.ħ == 2 && op_block.ħ == 2
     end
 
     @testset "squeeze operator" begin
@@ -36,39 +37,37 @@
         @test squeeze(qblockbasis, rs, thetas) == changebasis(QuadBlockBasis, squeeze(qpairbasis, rs, thetas))
         @test issymplectic(qpairbasis, op_pair.symplectic, atol = 1e-4)
         @test isgaussian(op_pair, atol = 1e-4)
+        @test op_pair.ħ == 2 && op_block.ħ == 2
     end
 
     @testset "two-mode squeeze operator" begin
         r, theta = rand(Float64), rand(Float64)
         rs, thetas = rand(Float64, nmodes), rand(Float64, nmodes)
-        op = twosqueeze(2*qpairbasis, r, theta)
-        @test op isa GaussianUnitary
-        @test twosqueeze(Array, 2*qpairbasis, r, theta) isa GaussianUnitary
-        @test twosqueeze(SVector{4*nmodes}, SMatrix{4*nmodes,4*nmodes}, 2*qpairbasis, r, theta) isa GaussianUnitary
+        op, op_array, op_static = twosqueeze(2*qpairbasis, r, theta), twosqueeze(Array, 2*qpairbasis, r, theta), twosqueeze(SVector{4*nmodes}, SMatrix{4*nmodes,4*nmodes}, 2*qpairbasis, r, theta)
+        @test op isa GaussianUnitary && op_array isa GaussianUnitary && op_static isa GaussianUnitary
         @test twosqueeze(2*qblockbasis, r, theta) == changebasis(QuadBlockBasis, op)
         @test twosqueeze(2*qblockbasis, rs, thetas) == changebasis(QuadBlockBasis, twosqueeze(2*qpairbasis, rs, thetas))
+        @test op.ħ == 2 && op_array.ħ == 2 && op_static.ħ == 2
     end
 
     @testset "phase-shift operator" begin
         theta = rand(Float64)
         thetas = rand(Float64, nmodes)
-        op = phaseshift(qpairbasis, theta)
-        @test op isa GaussianUnitary
-        @test phaseshift(Array, qpairbasis, theta) isa GaussianUnitary
-        @test phaseshift(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis, theta) isa GaussianUnitary
+        op, op_array, op_static = phaseshift(qpairbasis, theta), phaseshift(Array, qpairbasis, theta), phaseshift(SVector{2*nmodes}, SMatrix{2*nmodes,2*nmodes}, qpairbasis, theta)
+        @test op isa GaussianUnitary && op_array isa GaussianUnitary && op_static isa GaussianUnitary
         @test phaseshift(qblockbasis, theta) == changebasis(QuadBlockBasis, op)
         @test phaseshift(qblockbasis, thetas) == changebasis(QuadBlockBasis, phaseshift(qpairbasis, thetas))
+        @test op.ħ == 2 && op_array.ħ == 2 && op_static.ħ == 2
     end
 
     @testset "beamsplitter operator" begin
         theta = rand(Float64)
         thetas = rand(Float64, nmodes)
-        op = beamsplitter(2*qpairbasis, theta)
-        @test op isa GaussianUnitary
-        @test beamsplitter(Array, 2*qpairbasis, theta) isa GaussianUnitary
-        @test beamsplitter(SVector{4*nmodes}, SMatrix{4*nmodes,4*nmodes}, 2*qpairbasis, theta) isa GaussianUnitary
+        op, op_array, op_static = beamsplitter(2*qpairbasis, theta), beamsplitter(Array, 2*qpairbasis, theta), beamsplitter(SVector{4*nmodes}, SMatrix{4*nmodes,4*nmodes}, 2*qpairbasis, theta)
+        @test op isa GaussianUnitary && op_array isa GaussianUnitary && op_static isa GaussianUnitary
         @test beamsplitter(2*qblockbasis, theta) == changebasis(QuadBlockBasis, op)
         @test beamsplitter(2*qblockbasis, thetas) == changebasis(QuadBlockBasis, beamsplitter(2*qpairbasis, thetas))
+        @test op.ħ == 2 && op_array.ħ == 2 && op_static.ħ == 2
     end
 
     @testset "tensor products" begin


### PR DESCRIPTION
This PR does the following:
- Adds an `ħ` field to `GaussianState`, `GaussianUnitary`, and `GaussianChannel`, which by default is `ħ = 2`. 
- Adds kwarg `ħ = 2` to every constructor method for the aforementioned types.
- Clean up docstrings for each constructor method to include arbitrary `ħ` equations and not have uncompiled LaTeX in the terminal.
- Throws error message when operations are computed between Gaussian objects with different conventions for `ħ` are used.
- Includes `ħ` in purity metric and `isgaussian` checks.

Edit: this PR implements breaking changes. Specifically,  default `ħ` conventions for `thermalstate`, `coherentstate`, `squeezedstate`, and `eprstate` are changed from `ħ = 1` to `ħ = 2`,  following the convention from Weedbrook et. al's review on Gaussian quantum information. This is also done to maintain the same default value of `ħ = 2` for other states and operators.