### PR TITLE
Implement two-mode summing unitary

### DIFF
--- a/src/Gabs.jl
+++ b/src/Gabs.jl
@@ -21,7 +21,7 @@ export
     vacuumstate, thermalstate, coherentstate, squeezedstate, eprstate,
     # predefined Gaussian channels
     displace, squeeze, twosqueeze, phaseshift, beamsplitter,
-    attenuator, amplifier, twosumgate,
+    attenuator, amplifier, sum_gate,
     # random objects
     randstate, randunitary, randchannel, randsymplectic,
     # wigner functions

--- a/src/Gabs.jl
+++ b/src/Gabs.jl
@@ -21,7 +21,7 @@ export
     vacuumstate, thermalstate, coherentstate, squeezedstate, eprstate,
     # predefined Gaussian channels
     displace, squeeze, twosqueeze, phaseshift, beamsplitter,
-    attenuator, amplifier,
+    attenuator, amplifier, twosumgate,
     # random objects
     randstate, randunitary, randchannel, randsymplectic,
     # wigner functions

--- a/src/unitaries.jl
+++ b/src/unitaries.jl
@@ -538,102 +538,66 @@ function _beamsplitter(basis::QuadBlockBasis{N}, transmit::R) where {N<:Int,R<:V
 end
 
 """
-Constructs the **two-mode sum gate** (SUM gate), a fundamental operation
-in continuous-variable quantum computing.The SUM gate applies a transformation
-that displaces one oscillator's quadrature by an amount proportional to the
-position quadrature of another oscillator.
+Constructs the two-mode SUM gate as a Gaussian unitary operator.
 
-## Mathematical description of a two-mode sum gate
-
-For two oscillators `a` and `b`, the SUM gate is defined as: SUM(λ) = exp(-i 2λ ẋₐ p̂_b)
-which transforms position eigenstates as: SUM(λ) |xₐ⟩ |x_b⟩ = |xₐ⟩ |x_b + λ xₐ⟩.
-
-The SUM gate can be realized using a [`beamsplitter`](@ref) and [`squeeze`](@ref),
-following the *Bloch-Messiah decomposition*:
-
-```math
-\begin{align}
-\text{SUM}(\\lambda) &= \\text{BS}(\\pi + 2\\theta, -\\pi/2) \\left[ s(r) \\otimes s(-r) \\right] \text{BS}(2\\theta, -\\pi/2), \\
-\\sinh r &= \frac{\\lambda}{2}, \\
-\\cos(2\\theta) &= \\tanh(r), \\
-\\sin(2\\theta) &= -\\text{sech}(r)
-\end{align}
-```
-
-where:
-- `sinh(r) = λ / 2` (squeezing parameter),
-- `cos(2θ) = tanh(r)`, `sin(2θ) = -sech(r)` (beam splitter angles).
-
-## Example
-
-```julia
-julia> twosumgate(QuadBlockBasis(2), 1.0)
+```jldoctest
+julia> sum_gate(QuadPairBasis(2))
 GaussianUnitary for 2 modes.
-  symplectic basis: QuadBlockBasis
+  symplectic basis: QuadPairBasis
 displacement: 4-element Vector{Float64}:
  0.0
  0.0
  0.0
  0.0
 symplectic: 4×4 Matrix{Float64}:
-  0.17082   0.894427   0.0       0.0
- -0.894427  1.17082    0.0       0.0
-  0.0       0.0        1.17082   0.894427
-  0.0       0.0       -0.894427  0.17082
+ 1.0  0.0  0.0   0.0
+ 0.0  1.0  0.0  -1.0
+ 1.0  0.0  1.0   0.0
+ 0.0  0.0  0.0   1.0
 ```
-
 """
-function twosumgate(::Type{Td}, ::Type{Ts}, basis::SymplecticBasis{N}, lambda::R; ħ = 2) where {Td,Ts,N<:Int,R<:Real}
-    disp, symplectic = _twosumgate(basis, lambda)
+function sum_gate(::Type{Td}, ::Type{Ts}, basis::SymplecticBasis{N}; ħ = 2) where {Td, Ts, N}
+    disp, symplectic = _sum_gate(basis)
     return GaussianUnitary(basis, Td(disp), Ts(symplectic); ħ = ħ)
 end
-twosumgate(::Type{T}, basis::SymplecticBasis{N}, lambda::R; ħ = 2) where {T,N<:Int,R} = twosumgate(T, T, basis, lambda; ħ = ħ)
-function twosumgate(basis::SymplecticBasis{N}, lambda::R; ħ = 2) where {N<:Int,R<:Real}
-    disp, symplectic = _twosumgate(basis, lambda)
+function sum_gate(::Type{T}, basis::SymplecticBasis{N}; ħ = 2) where {T, N}
+    return sum_gate(T, T, basis; ħ = ħ)
+end
+function sum_gate(basis::SymplecticBasis{N}; ħ = 2) where {N}
+    disp, symplectic = _sum_gate(basis)
     return GaussianUnitary(basis, disp, symplectic; ħ = ħ)
 end
-function _twosumgate(basis::QuadPairBasis{N}, lambda::R) where {N,R<:Real}
-    # Compute the squeezing parameter from sinh(r) = lambda/2
-    r = asinh(lambda / 2)
-    # Determine the beam-splitter mixing angle: cos(2θ) = tanh(r), sin(2θ) = -sech(r)
-    twoθ = -acos(tanh(r))
-    θ = twoθ / 2
-    # First beam splitter: BS(2θ, -π/2)
-    transmit1 = cos(2θ)^2
-    BS1 = _beamsplitter(basis, transmit1)
-    # Single-mode squeezing: S1 ⊗ S2
-    S1 = squeeze(QuadPairBasis(basis.nmodes - 1), r, 0.0)
-    S2 = squeeze(QuadPairBasis(basis.nmodes - 1), -r, 0.0)
-    S_tensor = S1 ⊗ S2
-    # Second beam splitter: BS(π+2θ, -π/2)
-    transmit2 = cos(π + 2θ)^2
-    BS2 = _beamsplitter(basis, transmit2)
-    # Compose the operations
-    final_symplectic = BS2[2] * S_tensor.symplectic * BS1[2]
-    final_disp = BS2[1] + S_tensor.disp + BS1[1]
-    return final_disp, final_symplectic
+function _sum_gate(basis::QuadBlockBasis{N}) where {N<:Int}
+    nmodes = basis.nmodes
+    if nmodes != 2
+        error("SUM gate is defined for 2-mode systems only.")
+    end
+    disp = zeros(Float64, 2 * nmodes)
+    symplectic = zeros(Float64, 2 * nmodes, 2 * nmodes)
+    symplectic[1, 1] = 1.0
+    symplectic[2, 1] = 1.0
+    symplectic[2, 2] = 1.0
+    symplectic[3, 3] = 1.0
+    symplectic[3, 4] = -1.0
+    symplectic[4, 4] = 1.0
+    return disp, symplectic
 end
-
-function _twosumgate(basis::QuadBlockBasis{N}, lambda::R) where {N,R<:Real}
-    # Compute the squeezing parameter from sinh(r) = lambda/2
-    r = asinh(lambda / 2)
-    # Determine the beam-splitter mixing angle: cos(2θ) = tanh(r), sin(2θ) = -sech(r)
-    twoθ = -acos(tanh(r))
-    θ = twoθ / 2
-    # First beam splitter: BS(2θ, -π/2)
-    transmit1 = cos(2θ)^2
-    BS1 = _beamsplitter(basis, transmit1)
-    # Single-mode squeezing: S1 ⊗ S2
-    S1 = squeeze(QuadPairBasis(basis.nmodes - 1), r, 0.0)
-    S2 = squeeze(QuadPairBasis(basis.nmodes - 1), -r, 0.0)
-    S_tensor = S1 ⊗ S2
-    # Second beam splitter: BS(π+2θ, -π/2)
-    transmit2 = cos(π + 2θ)^2
-    BS2 = _beamsplitter(basis, transmit2)
-    # Compose the operations
-    final_symplectic = BS2[2] * S_tensor.symplectic * BS1[2]
-    final_disp = BS2[1] + S_tensor.disp + BS1[1]
-    return final_disp, final_symplectic
+function _sum_gate(basis::QuadPairBasis{N}) where {N<:Int}
+    nmodes = basis.nmodes
+    if nmodes != 2
+        error("SUM gate is defined for 2-mode systems only.")
+    end
+    disp = zeros(Float64, 2 * nmodes)
+    S = [1.0 0.0 0.0 0.0;
+         1.0 1.0 0.0 0.0;
+         0.0 0.0 1.0 -1.0;
+         0.0 0.0 0.0 1.0]
+    P = [1.0 0.0 0.0 0.0;
+         0.0 0.0 1.0 0.0;
+         0.0 1.0 0.0 0.0;
+         0.0 0.0 0.0 1.0]
+    symplectic = P * S * P'
+    return disp, symplectic
 end
 
 ##


### PR DESCRIPTION
This PR aims to fix #38 by implementing two-mode summing unitary.

Hi, Andrew! Thank you for your help and guidance! I am not sure why I landed to page 123 😅 of [https://journals.aps.org/prl/pdf/10.1103/PhysRevLett.88.09790](https://journals.aps.org/prl/pdf/10.1103/PhysRevLett.88.097904).  As you suggestion, I need to follow the information given much earlier in the paper!

The SUM gate can be realized using  *beamsplitter* and *squeeze*, following the *Bloch-Messiah decomposition*:

```math
\begin{align}
\text{SUM}(\lambda) &= \text{BS}(\pi + 2\theta, -\pi/2) \left[ s(r) \otimes s(-r) \right] \text{BS}(2\theta, -\pi/2), \tag{209} \\
\sinh r &= \frac{\lambda}{2}, \tag{210} \\
\cos(2\theta) &= \tanh(r), \tag{211} \\
\sin(2\theta) &= -\text{sech}(r). \tag{212}
\end{align}
```

Therefore, we can use the already implemented operators `squeeze `and `beamsplitter` and use them to implement the `twosumgate`. The name follows the convention of similar to `twosqueeze`. I hope that this attempt is better than the previous attempt at least 😅   `beamsplitter` appears to not have the parameter to extra phase shift to I have excluded $-\pi/2$

```julia
julia> using Gabs;  using Gabs: twosumgate

julia> basis = QuadBlockBasis(2)
QuadBlockBasis(2)

julia> lambda = 1.0
1.0

julia> twosumgate(basis, lambda)
GaussianUnitary for 2 modes.
  symplectic basis: QuadBlockBasis
displacement: 4-element Vector{Float64}:
 0.0
 0.0
 0.0
 0.0
symplectic: 4×4 Matrix{Float64}:
  0.17082   0.894427   0.0       0.0
 -0.894427  1.17082    0.0       0.0
  0.0       0.0        1.17082   0.894427
  0.0       0.0       -0.894427  0.17082
```

Edit:

I was wondering whether the following can be implemented as a test to check whether the correctness of approach. It seems that excluding extra phase $\phi$ of $\pi$ in $BS(\theta, \phi)$ changes the symplectic matrix 😅.  According to 199, the two mode squeeze can be written after Bloch- Messiah decomposition as 
```math
TMS(r, \frac{\pi}{2}) = BS\left(\frac{\pi}{2}, 0\right) \left[s(r) \otimes s(r)\right] BS\left(\frac{\pi}{2}, \pi\right)
```
which can be written as excluding extra phase $\phi$ of $\pi$ in $BS(\theta, \phi)$:

```julia
function _test_twomode_squeeze(basis, r, theta)
    transmit1 = theta/2
    BS1 = beamsplitter(basis, transmit1)
    S1 = squeeze(QuadPairBasis(basis.nmodes - 1), r, 0.0)
    S2 = squeeze(QuadPairBasis(basis.nmodes - 1), r, 0.0)
    S_tensor = S1 ⊗ S2
    transmit2 = theta/2
    BS2 = beamsplitter(basis, transmit2)
    final_symplectic = BS2.symplectic * S_tensor.symplectic * BS1.symplectic
    final_disp = BS2.disp + S_tensor.disp + BS1.disp
    return final_disp, final_symplectic
end

julia> r, theta = rand(Float64), rand(Float64)
(0.2695878972298862, 0.38699466312747455)

julia> basis = QuadPairBasis(2)
QuadPairBasis(2)

julia> _test_twomode_squeeze(basis,r,theta)[1]
4-element Vector{Float64}:
 0.0
 0.0
 0.0
 0.0

julia> _test_twomode_squeeze(basis,r,theta)[2]
4×4 Matrix{Float64}:
  0.468149   0.0       0.603379  0.0
  0.0        0.802684  0.0       1.03455
 -0.603379   0.0       0.468149  0.0
  0.0       -1.03455   0.0       0.802684

julia> twosqueeze(basis, r, theta)
GaussianUnitary for 2 modes.
  symplectic basis: QuadPairBasis
displacement: 4-element Vector{Float64}:
 0.0
 0.0
 0.0
 0.0
symplectic: 4×4 Matrix{Float64}:
  1.03656    0.0       -0.252686  -0.102981
  0.0        1.03656   -0.102981   0.252686
 -0.252686  -0.102981   1.03656    0.0
 -0.102981   0.252686   0.0        1.03656
```

The current approach appears to be incorrect. I initially thought we could use the Bloch-Messiah decomposition for the two-sum gate and then leverage it to implement the gate. 😅 