### PR TITLE
Remove Symbolics.jl as a dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,6 @@ version = "1.2.9-dev"
 BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 QuantumInterface = "5717a53b-5d69-4fa3-b976-0bf2f97ca1e5"
-Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 SymplecticFactorizations = "7425e8e4-4cde-4e45-9b2f-a15679260f9b"
 
 [weakdeps]
@@ -29,7 +28,8 @@ SymplecticFactorizations = "0.1.5"
 julia = "1.6.7, 1.10.0"
 
 [extras]
+Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Makie", "StaticArrays"]
+test = ["Test", "Makie", "StaticArrays", "Symbolics"]


### PR DESCRIPTION
Added in #44 when creating tests. Gabs doesn't need to be directly dependent on Symbolics.jl, the symbolic variables form that ecosystem should "just work". So we really only need Symbolics.jl as a test dependency.