### PR TITLE
Fix `ptrace` and add corresponding index errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # News
 
-## v1.2.9 - dev
+## v1.2.9 - 2025-04-15
 
 - Add seminal papers section to documentation.
 - **(breaking)** Add `hbar=2` as default convention in Gabs.
@@ -9,6 +9,7 @@
 - Add support for `entropy_vn`, `fidelity`, and `logarithmic_negativity` metrics.
 - Optimised `changebasis` to avoid matrix multiplication.
 - **(breaking)** Implement revamped `generaldyne` interface.
+- **(fix)** Trace out indices in `ptrace` indicated by `indices` rather than `setdiff(1:nmodes, indices)`.
 
 ## v1.2.8 - 2025-02-06
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Gabs"
 uuid = "0eb812ee-a11f-4f5e-b8d4-bb8a44f06f50"
 authors = ["Andrew Kille"]
-version = "1.2.9-dev"
+version = "1.2.9"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -388,21 +388,29 @@ covariance: 8×8 Matrix{Float64}:
  0.0  0.0  0.0  0.0  -23.6338   13.645     0.0      27.3082
 
 julia> ptrace(state, 1)
-GaussianState for 1 mode.
+GaussianState for 3 modes.
   symplectic basis: QuadPairBasis
-mean: 2-element Vector{Float64}:
-  2.0
- -2.0
-covariance: 2×2 Matrix{Float64}:
- 1.0  0.0
- 0.0  1.0
+mean: 6-element Vector{Float64}:
+  4.0
+ -4.0
+  0.0
+  0.0
+  0.0
+  0.0
+covariance: 6×6 Matrix{Float64}:
+ 1.0  0.0    0.0       0.0       0.0       0.0
+ 0.0  1.0    0.0       0.0       0.0       0.0
+ 0.0  0.0   27.3082    0.0     -13.645   -23.6338
+ 0.0  0.0    0.0      27.3082  -23.6338   13.645
+ 0.0  0.0  -13.645   -23.6338   27.3082    0.0
+ 0.0  0.0  -23.6338   13.645     0.0      27.3082
 
 julia> ptrace(state, [1, 4])
 GaussianState for 2 modes.
   symplectic basis: QuadPairBasis
 mean: 4-element Vector{Float64}:
-  2.0
- -2.0
+  4.0
+ -4.0
   0.0
   0.0
 covariance: 4×4 Matrix{Float64}:

--- a/docs/src/tutorials.md
+++ b/docs/src/tutorials.md
@@ -166,8 +166,8 @@ Use [Latexify](https://github.com/korsbo/Latexify.jl) to render the covariance m
 \begin{equation}
 \left[
 \begin{array}{cc}
-\left( \cosh\left( 2 r \right) \sqrt{1 - \tau} - \cos\left( \theta \right) \sinh\left( 2 r \right) \sqrt{\tau} \right) \sqrt{1 - \tau} + \left( \sqrt{\tau} \cosh\left( 2 r \right) - \cos\left( \theta \right) \sinh\left( 2 r \right) \sqrt{1 - \tau} \right) \sqrt{\tau} &  - 2 \sinh\left( 2 r \right) \sin\left( \theta \right) \sqrt{\tau} \sqrt{1 - \tau} \\
- - 2 \sinh\left( 2 r \right) \sin\left( \theta \right) \sqrt{\tau} \sqrt{1 - \tau} & \left( \cosh\left( 2 r \right) \sqrt{1 - \tau} + \cos\left( \theta \right) \sinh\left( 2 r \right) \sqrt{\tau} \right) \sqrt{1 - \tau} + \left( \sqrt{\tau} \cosh\left( 2 r \right) + \cos\left( \theta \right) \sinh\left( 2 r \right) \sqrt{1 - \tau} \right) \sqrt{\tau} \\
+\left( \cosh\left( 2 r \right) \sqrt{1 - \tau} + \cos\left( \theta \right) \sinh\left( 2 r \right) \sqrt{\tau} \right) \sqrt{1 - \tau} - \left(  - \sqrt{\tau} \cosh\left( 2 r \right) - \cos\left( \theta \right) \sinh\left( 2 r \right) \sqrt{1 - \tau} \right) \sqrt{\tau} & 2 \sinh\left( 2 r \right) \sin\left( \theta \right) \sqrt{\tau} \sqrt{1 - \tau} \\
+2 \sinh\left( 2 r \right) \sin\left( \theta \right) \sqrt{\tau} \sqrt{1 - \tau} & \left( \cosh\left( 2 r \right) \sqrt{1 - \tau} - \cos\left( \theta \right) \sinh\left( 2 r \right) \sqrt{\tau} \right) \sqrt{1 - \tau} - \left(  - \sqrt{\tau} \cosh\left( 2 r \right) + \cos\left( \theta \right) \sinh\left( 2 r \right) \sqrt{1 - \tau} \right) \sqrt{\tau} \\
 \end{array}
 \right]
 \end{equation}


### PR DESCRIPTION
Originally traced out indices in `setdiff(1:nmodes, indices)` rather than the vector `indices` itself, which is nonintuitive and unintended.