### PR TITLE
Mode indices for the apply! function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # News
 
+## v1.3.7 - 2026-06-06
+
+- Add `apply!(gaussian_state, gaussian_unitary, indices)` method that allows a unitary to be applied to only some modes of a state.
+
 ## v1.3.6 - 2026-03-19
 
 - Allow `homodyne`, `generaldyne`, and their corresponding `rand(...)` interfaces to measure single-mode Gaussian states.

--- a/src/types.jl
+++ b/src/types.jl
@@ -141,9 +141,24 @@ function apply!(state::GaussianState{B,M,V}, op::GaussianUnitary, indices::Abstr
         quad_indices[2k]   = 2i
     end
     d, S = op.disp, op.symplectic
-    @views state.mean[quad_indices] .= S * state.mean[quad_indices] .+ d
-    @views state.covar[quad_indices, :] .= S * state.covar[quad_indices, :]
-    @views state.covar[:, quad_indices] .= state.covar[:, quad_indices] * transpose(S)
+    m = length(quad_indices)
+    n = size(state.covar, 1)
+    mean_sub = @view state.mean[quad_indices]
+    covar_row = @view state.covar[quad_indices, :]
+    covar_col = @view state.covar[:, quad_indices]
+    # single scratch buffer, reused across the three products (reshaped for the column update)
+    buf = similar(state.covar, m, n)
+    buf_vec = @view buf[1:m]
+    # x̄[q] ← S x̄[q] + d
+    mul!(buf_vec, S, mean_sub)
+    mean_sub .= buf_vec .+ d
+    # V[q,:] ← S V[q,:]
+    mul!(buf, S, covar_row)
+    covar_row .= buf
+    # V[:,q] ← V[:,q] Sᵀ (reads the just-updated V[q,q] block)
+    buf_col = reshape(buf, n, m)
+    mul!(buf_col, covar_col, transpose(S))
+    covar_col .= buf_col
     return state
 end
 function apply!(state::GaussianState{B,M,V}, op::GaussianUnitary, indices::AbstractVector{<:Int}) where {B<:QuadBlockBasis,M,V}
@@ -157,9 +172,24 @@ function apply!(state::GaussianState{B,M,V}, op::GaussianUnitary, indices::Abstr
         quad_indices[k+l] = i + state.basis.nmodes
     end
     d, S = op.disp, op.symplectic
-    @views state.mean[quad_indices] .= S * state.mean[quad_indices] .+ d
-    @views state.covar[quad_indices, :] .= S * state.covar[quad_indices, :]
-    @views state.covar[:, quad_indices] .= state.covar[:, quad_indices] * transpose(S)
+    m = length(quad_indices)
+    n = size(state.covar, 1)
+    mean_sub = @view state.mean[quad_indices]
+    covar_row = @view state.covar[quad_indices, :]
+    covar_col = @view state.covar[:, quad_indices]
+    # single scratch buffer, reused across the three products (reshaped for the column update)
+    buf = similar(state.covar, m, n)
+    buf_vec = @view buf[1:m]
+    # x̄[q] ← S x̄[q] + d
+    mul!(buf_vec, S, mean_sub)
+    mean_sub .= buf_vec .+ d
+    # V[q,:] ← S V[q,:]
+    mul!(buf, S, covar_row)
+    covar_row .= buf
+    # V[:,q] ← V[:,q] Sᵀ (reads the just-updated V[q,q] block)
+    buf_col = reshape(buf, n, m)
+    mul!(buf_col, covar_col, transpose(S))
+    covar_col .= buf_col
     return state
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -132,7 +132,7 @@ end
 In-place application of a Gaussian unitary `op` on the mode indices `indices` of a Gaussian state `state`.
 """
 function apply!(state::GaussianState{B,M,V}, op::GaussianUnitary, indices::AbstractVector{<:Int}) where {B<:QuadPairBasis,M,V}
-    # op.basis == state.basis || throw(DimensionMismatch(ACTION_ERROR))
+    typeof(op.basis) == typeof(state.basis) || throw(DimensionMismatch(ACTION_ERROR))
     op.ħ == state.ħ || throw(ArgumentError(HBAR_ERROR))
     length(indices) ≤ state.basis.nmodes || throw(ArgumentError(INDEX_ERROR))
     quad_indices = collect(Iterators.flatten((2i - 1, 2i) for i in indices))
@@ -143,7 +143,7 @@ function apply!(state::GaussianState{B,M,V}, op::GaussianUnitary, indices::Abstr
     return state
 end
 function apply!(state::GaussianState{B,M,V}, op::GaussianUnitary, indices::AbstractVector{<:Int}) where {B<:QuadBlockBasis,M,V}
-    # op.basis == state.basis || throw(DimensionMismatch(ACTION_ERROR))
+    typeof(op.basis) == typeof(state.basis) || throw(DimensionMismatch(ACTION_ERROR))
     op.ħ == state.ħ || throw(ArgumentError(HBAR_ERROR))
     length(indices) ≤ state.basis.nmodes || throw(ArgumentError(INDEX_ERROR))
     quad_indices = [indices; indices .+ state.basis.nmodes]

--- a/src/types.jl
+++ b/src/types.jl
@@ -142,11 +142,6 @@ function apply!(state::GaussianState{B,M,V}, op::GaussianUnitary, indices::Abstr
     @views state.covar[:, quad_indices] .= state.covar[:, quad_indices] * transpose(S)
     return state
 end
-"""
-    apply!(state::GaussianState, op::GaussianUnitary, indices::AbstractVector{<:Int})
-
-In-place application of a Gaussian unitary `op` on the mode indices `indices` of a Gaussian state `state`.
-"""
 function apply!(state::GaussianState{B,M,V}, op::GaussianUnitary, indices::AbstractVector{<:Int}) where {B<:QuadBlockBasis,M,V}
     # op.basis == state.basis || throw(DimensionMismatch(ACTION_ERROR))
     op.ħ == state.ħ || throw(ArgumentError(HBAR_ERROR))

--- a/src/types.jl
+++ b/src/types.jl
@@ -126,6 +126,38 @@ function apply!(state::GaussianState, op::GaussianUnitary)
     state.covar .= S * state.covar * transpose(S)
     return state
 end
+"""
+    apply!(state::GaussianState, op::GaussianUnitary, indices::AbstractVector{<:Int})
+
+In-place application of a Gaussian unitary `op` on the mode indices `indices` of a Gaussian state `state`.
+"""
+function apply!(state::GaussianState{B,M,V}, op::GaussianUnitary, indices::AbstractVector{<:Int}) where {B<:QuadPairBasis,M,V}
+    # op.basis == state.basis || throw(DimensionMismatch(ACTION_ERROR))
+    op.ħ == state.ħ || throw(ArgumentError(HBAR_ERROR))
+    length(indices) ≤ state.basis.nmodes || throw(ArgumentError(INDEX_ERROR))
+    quad_indices = collect(Iterators.flatten((2i - 1, 2i) for i in indices))
+    d, S = op.disp, op.symplectic
+    @views state.mean[quad_indices] .= S * state.mean[quad_indices] .+ d
+    @views state.covar[quad_indices, :] .= S * state.covar[quad_indices, :]
+    @views state.covar[:, quad_indices] .= state.covar[:, quad_indices] * transpose(S)
+    return state
+end
+"""
+    apply!(state::GaussianState, op::GaussianUnitary, indices::AbstractVector{<:Int})
+
+In-place application of a Gaussian unitary `op` on the mode indices `indices` of a Gaussian state `state`.
+"""
+function apply!(state::GaussianState{B,M,V}, op::GaussianUnitary, indices::AbstractVector{<:Int}) where {B<:QuadBlockBasis,M,V}
+    # op.basis == state.basis || throw(DimensionMismatch(ACTION_ERROR))
+    op.ħ == state.ħ || throw(ArgumentError(HBAR_ERROR))
+    length(indices) ≤ state.basis.nmodes || throw(ArgumentError(INDEX_ERROR))
+    quad_indices = [indices; indices .+ state.basis.nmodes]
+    d, S = op.disp, op.symplectic
+    @views state.mean[quad_indices] .= S * state.mean[quad_indices] .+ d
+    @views state.covar[quad_indices, :] .= S * state.covar[quad_indices, :]
+    @views state.covar[:, quad_indices] .= state.covar[:, quad_indices] * transpose(S)
+    return state
+end
 
 """
 Defines a Gaussian channel for an N-mode bosonic system over a 2N-dimensional phase space.

--- a/src/types.jl
+++ b/src/types.jl
@@ -135,7 +135,11 @@ function apply!(state::GaussianState{B,M,V}, op::GaussianUnitary, indices::Abstr
     typeof(op.basis) == typeof(state.basis) || throw(DimensionMismatch(ACTION_ERROR))
     op.ħ == state.ħ || throw(ArgumentError(HBAR_ERROR))
     length(indices) ≤ state.basis.nmodes || throw(ArgumentError(INDEX_ERROR))
-    quad_indices = collect(Iterators.flatten((2i - 1, 2i) for i in indices))
+    quad_indices = Vector{Int}(undef, 2length(indices))
+    @inbounds for (k, i) in enumerate(indices)
+        quad_indices[2k-1] = 2i - 1
+        quad_indices[2k]   = 2i
+    end
     d, S = op.disp, op.symplectic
     @views state.mean[quad_indices] .= S * state.mean[quad_indices] .+ d
     @views state.covar[quad_indices, :] .= S * state.covar[quad_indices, :]
@@ -146,7 +150,12 @@ function apply!(state::GaussianState{B,M,V}, op::GaussianUnitary, indices::Abstr
     typeof(op.basis) == typeof(state.basis) || throw(DimensionMismatch(ACTION_ERROR))
     op.ħ == state.ħ || throw(ArgumentError(HBAR_ERROR))
     length(indices) ≤ state.basis.nmodes || throw(ArgumentError(INDEX_ERROR))
-    quad_indices = [indices; indices .+ state.basis.nmodes]
+    l = length(indices)
+    quad_indices = Vector{Int}(undef, 2l)
+    @inbounds for (k, i) in enumerate(indices)
+        quad_indices[k]   = i
+        quad_indices[k+l] = i + state.basis.nmodes
+    end
     d, S = op.disp, op.symplectic
     @views state.mean[quad_indices] .= S * state.mean[quad_indices] .+ d
     @views state.covar[quad_indices, :] .= S * state.covar[quad_indices, :]

--- a/test/test_autodiff.jl
+++ b/test/test_autodiff.jl
@@ -44,5 +44,5 @@
         @test isapprox(findiff_f1, fordiff_f1, atol = 1e-4)
 
     end
-
+end
         

--- a/test/test_unitaries.jl
+++ b/test/test_unitaries.jl
@@ -141,9 +141,11 @@
             embedded_two = embed(full_basis, [1, 3], op_two)
             transformed_13 = op_two * (s1 ⊗ s3)
             result = embedded_two * input_state
+            inplace_13 = apply!(input_state, op_two, [1, 3])
 
             @test ptrace(result, 2) == transformed_13
             @test ptrace(result, [1, 3]) == s2
+            @test result == inplace_13
         end
 
         @test_throws AssertionError embed(QuadPairBasis(3), [1, 2, 3, 4], displace(QuadPairBasis(1), α))


### PR DESCRIPTION
This PR adds new methods to apply! that allow the user to specify to which modes of a large GaussianState a GaussianUnitary should be applied, without calling embed(), which can be expensive for large states. A feature like this will be very helpful for the new version of [Genqo.jl](https://github.com/QuantumSavory/Genqo.jl) I'm working on.

- [x] The code is properly formatted and commented.
- [ ] Substantial new functionality is documented within the docs.
- [x] All new functionality is tested.
- [ ] All of the automated tests on github pass.
- [ ] We recently started enforcing formatting checks. If formatting issues are reported in the new code you have written, please correct them. <small>There will be plenty of old code that is flagged as we are slowly transitioning to enforced formatting. Please do not worry about or address older formatting issues -- keep your PR just focused on your planned contribution.</small>

If you are submitting for a bug bounty:
- [ ] I have read and followed the [AI usage and disclosure policy](https://github.com/QuantumSavory/.github/blob/main/BUG_BOUNTIES.md)

If possible, keep your git history not too wild (rebase and squash commits, keep commits small and semantically separated) so that review is easier.
