### PR TITLE
Fix Documenter deployment target

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -39,6 +39,7 @@ function main()
 
     deploydocs(
         repo = "github.com/QuantumSavory/Gabs.jl.git",
+        devbranch = "main",
         push_preview = true,
     )
 end

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -38,7 +38,8 @@ function main()
     )
 
     deploydocs(
-        repo = "github.com/apkille/Gabs.jl.git"
+        repo = "github.com/QuantumSavory/Gabs.jl.git",
+        push_preview = true,
     )
 end
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -39,7 +39,6 @@ function main()
 
     deploydocs(
         repo = "github.com/QuantumSavory/Gabs.jl.git",
-        devbranch = "main",
         push_preview = true,
     )
 end


### PR DESCRIPTION
## Summary

- point Documenter deployment at the current QuantumSavory/Gabs.jl repository
- enable pull-request preview deployment
- leave the existing canonical documentation URL unchanged

## Validation

- parsed docs/make.jl with Julia
- verified the staged diff with git diff --check