### PR TITLE
Normalize indexed apply! argument order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # News
 
+## v1.3.8 - 2026-08-04
+
+- Normalize indexed operations to `apply!(state, indices, operation)` and support
+  indexed Gaussian channels. The former `apply!(state, operation, indices)` form
+  for Gaussian unitaries is deprecated but remains available for compatibility.
+
 ## v1.3.7 - 2026-06-06
 
-- Add `apply!(gaussian_state, gaussian_unitary, indices)` method that allows a unitary to be applied to only some modes of a state.
+- Add indexed application of a Gaussian unitary to selected modes of a state.
 
 ## v1.3.6 - 2026-03-19
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Gabs"
 uuid = "0eb812ee-a11f-4f5e-b8d4-bb8a44f06f50"
 authors = ["Andrew Kille"]
-version = "1.3.7"
+version = "1.3.8"
 
 [workspace]
 projects = ["test", "test/projects/jet"]

--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -188,6 +188,9 @@ covariance: 4×4 Matrix{Float64}:
  0.0      0.0      0.0      1.24483
 ```
 
+To apply a Gaussian unitary or channel to selected modes, place the mode index or
+indices before the operation: `apply!(state, indices, op)`.
+
 ## Tensor Products
 
 If we were operating in the state (Fock) space, and wanted to describe multi-mode Gaussian states,

--- a/src/types.jl
+++ b/src/types.jl
@@ -320,12 +320,79 @@ function apply!(state::GaussianState, index::Int, op::GaussianChannel)
     return apply!(state, [index], op)
 end
 function apply!(
-    state::GaussianState,
+    state::GaussianState{B,M,V},
     indices::AbstractVector{<:Int},
     op::GaussianChannel,
-)
-    embedded_op = embed(state.basis, collect(indices), op)
-    return apply!(state, embedded_op)
+) where {B<:QuadPairBasis,M,V}
+    typeof(op.basis) == typeof(state.basis) || throw(DimensionMismatch(ACTION_ERROR))
+    op.ħ == state.ħ || throw(ArgumentError(HBAR_ERROR))
+    length(indices) ≤ state.basis.nmodes || throw(ArgumentError(INDEX_ERROR))
+    quad_indices = Vector{Int}(undef, 2length(indices))
+    @inbounds for (k, i) in enumerate(indices)
+        quad_indices[2k-1] = 2i - 1
+        quad_indices[2k]   = 2i
+    end
+    d, T, N = op.disp, op.transform, op.noise
+    m = length(quad_indices)
+    n = size(state.covar, 1)
+    mean_sub = @view state.mean[quad_indices]
+    covar_row = @view state.covar[quad_indices, :]
+    covar_col = @view state.covar[:, quad_indices]
+    # single scratch buffer, reused across the three products (reshaped for the column update)
+    buf = similar(state.covar, m, n)
+    buf_vec = @view buf[1:m]
+    # x̄[q] ← T x̄[q] + d
+    mul!(buf_vec, T, mean_sub)
+    mean_sub .= buf_vec .+ d
+    # V[q,:] ← T V[q,:]
+    mul!(buf, T, covar_row)
+    covar_row .= buf
+    # V[:,q] ← V[:,q] Tᵀ (reads the just-updated V[q,q] block)
+    buf_col = reshape(buf, n, m)
+    mul!(buf_col, covar_col, transpose(T))
+    covar_col .= buf_col
+    # V[q,q] ← V[q,q] + N after both covariance transformations
+    covar_sub = @view state.covar[quad_indices, quad_indices]
+    covar_sub .+= N
+    return state
+end
+function apply!(
+    state::GaussianState{B,M,V},
+    indices::AbstractVector{<:Int},
+    op::GaussianChannel,
+) where {B<:QuadBlockBasis,M,V}
+    typeof(op.basis) == typeof(state.basis) || throw(DimensionMismatch(ACTION_ERROR))
+    op.ħ == state.ħ || throw(ArgumentError(HBAR_ERROR))
+    length(indices) ≤ state.basis.nmodes || throw(ArgumentError(INDEX_ERROR))
+    l = length(indices)
+    quad_indices = Vector{Int}(undef, 2l)
+    @inbounds for (k, i) in enumerate(indices)
+        quad_indices[k]   = i
+        quad_indices[k+l] = i + state.basis.nmodes
+    end
+    d, T, N = op.disp, op.transform, op.noise
+    m = length(quad_indices)
+    n = size(state.covar, 1)
+    mean_sub = @view state.mean[quad_indices]
+    covar_row = @view state.covar[quad_indices, :]
+    covar_col = @view state.covar[:, quad_indices]
+    # single scratch buffer, reused across the three products (reshaped for the column update)
+    buf = similar(state.covar, m, n)
+    buf_vec = @view buf[1:m]
+    # x̄[q] ← T x̄[q] + d
+    mul!(buf_vec, T, mean_sub)
+    mean_sub .= buf_vec .+ d
+    # V[q,:] ← T V[q,:]
+    mul!(buf, T, covar_row)
+    covar_row .= buf
+    # V[:,q] ← V[:,q] Tᵀ (reads the just-updated V[q,q] block)
+    buf_col = reshape(buf, n, m)
+    mul!(buf_col, covar_col, transpose(T))
+    covar_col .= buf_col
+    # V[q,q] ← V[q,q] + N after both covariance transformations
+    covar_sub = @view state.covar[quad_indices, quad_indices]
+    covar_sub .+= N
+    return state
 end
 
 """

--- a/src/types.jl
+++ b/src/types.jl
@@ -127,11 +127,20 @@ function apply!(state::GaussianState, op::GaussianUnitary)
     return state
 end
 """
-    apply!(state::GaussianState, op::GaussianUnitary, indices::AbstractVector{<:Int})
+    apply!(state::GaussianState, index::Int, op::GaussianUnitary)
+    apply!(state::GaussianState, indices::AbstractVector{<:Int}, op::GaussianUnitary)
 
-In-place application of a Gaussian unitary `op` on the mode indices `indices` of a Gaussian state `state`.
+In-place application of a Gaussian unitary `op` on the mode index or indices of a
+Gaussian state `state`.
 """
-function apply!(state::GaussianState{B,M,V}, op::GaussianUnitary, indices::AbstractVector{<:Int}) where {B<:QuadPairBasis,M,V}
+function apply!(state::GaussianState, index::Int, op::GaussianUnitary)
+    return apply!(state, [index], op)
+end
+function apply!(
+    state::GaussianState{B,M,V},
+    indices::AbstractVector{<:Int},
+    op::GaussianUnitary,
+) where {B<:QuadPairBasis,M,V}
     typeof(op.basis) == typeof(state.basis) || throw(DimensionMismatch(ACTION_ERROR))
     op.ħ == state.ħ || throw(ArgumentError(HBAR_ERROR))
     length(indices) ≤ state.basis.nmodes || throw(ArgumentError(INDEX_ERROR))
@@ -161,7 +170,11 @@ function apply!(state::GaussianState{B,M,V}, op::GaussianUnitary, indices::Abstr
     covar_col .= buf_col
     return state
 end
-function apply!(state::GaussianState{B,M,V}, op::GaussianUnitary, indices::AbstractVector{<:Int}) where {B<:QuadBlockBasis,M,V}
+function apply!(
+    state::GaussianState{B,M,V},
+    indices::AbstractVector{<:Int},
+    op::GaussianUnitary,
+) where {B<:QuadBlockBasis,M,V}
     typeof(op.basis) == typeof(state.basis) || throw(DimensionMismatch(ACTION_ERROR))
     op.ħ == state.ħ || throw(ArgumentError(HBAR_ERROR))
     length(indices) ≤ state.basis.nmodes || throw(ArgumentError(INDEX_ERROR))
@@ -192,6 +205,15 @@ function apply!(state::GaussianState{B,M,V}, op::GaussianUnitary, indices::Abstr
     covar_col .= buf_col
     return state
 end
+
+Base.@deprecate(
+    apply!(
+        state::GaussianState,
+        op::GaussianUnitary,
+        indices::AbstractVector{<:Int},
+    ),
+    apply!(state, indices, op)
+)
 
 """
 Defines a Gaussian channel for an N-mode bosonic system over a 2N-dimensional phase space.
@@ -280,8 +302,11 @@ function Base.:(*)(op::GaussianChannel, state::GaussianState)
 end
 """
     apply!(state::GaussianState, op::GaussianChannel)
+    apply!(state::GaussianState, index::Int, op::GaussianChannel)
+    apply!(state::GaussianState, indices::AbstractVector{<:Int}, op::GaussianChannel)
 
-In-place application of a Gaussian channel `op` on a Gaussian state `state`.
+In-place application of a Gaussian channel `op` on all or selected modes of a
+Gaussian state `state`.
 """
 function apply!(state::GaussianState, op::GaussianChannel)
     op.basis == state.basis || throw(DimensionMismatch(ACTION_ERROR))
@@ -290,6 +315,17 @@ function apply!(state::GaussianState, op::GaussianChannel)
     state.mean .= T * state.mean .+ d
     state.covar .= T * state.covar * transpose(T) .+ N
     return state
+end
+function apply!(state::GaussianState, index::Int, op::GaussianChannel)
+    return apply!(state, [index], op)
+end
+function apply!(
+    state::GaussianState,
+    indices::AbstractVector{<:Int},
+    op::GaussianChannel,
+)
+    embedded_op = embed(state.basis, collect(indices), op)
+    return apply!(state, embedded_op)
 end
 
 """

--- a/test/test_channels.jl
+++ b/test/test_channels.jl
@@ -176,6 +176,10 @@
             expected = s1 ⊗ s2 ⊗ (op * s3)
             @test embedded.basis == full_basis
             @test embedded * input_state == expected
+
+            inplace_state = copy(input_state)
+            @test apply!(inplace_state, 3, op) === inplace_state
+            @test inplace_state ≈ expected
         end
 
         for basis in (QuadPairBasis(2), QuadBlockBasis(2))
@@ -192,9 +196,12 @@
             embedded_two = embed(full_basis, [1, 3], op_two)
             transformed_13 = op_two * (s1 ⊗ s3)
             result = embedded_two * input_state
+            inplace_13 = apply!(input_state, [1, 3], op_two)
 
             @test ptrace(result, 2) == transformed_13
             @test ptrace(result, [1, 3]) == s2
+            @test inplace_13 === input_state
+            @test inplace_13 ≈ result
         end
 
         @test_throws AssertionError embed(QuadPairBasis(3), [1, 2, 3, 4], displace(QuadPairBasis(1), α, zeros(2, 2)))

--- a/test/test_doctests.jl
+++ b/test/test_doctests.jl
@@ -1,6 +1,7 @@
 @testitem "Doctests" tags=[:doctests] begin
     using Documenter
     using Gabs
+    using StaticArrays # Preload the extension before Documenter captures REPL output.
 
     DocMeta.setdocmeta!(Gabs, :DocTestSetup, :(using Gabs); recursive=true)
     doctest(Gabs)

--- a/test/test_unitaries.jl
+++ b/test/test_unitaries.jl
@@ -126,6 +126,10 @@
             expected = s1 ⊗ (op * s2) ⊗ s3
             @test embedded.basis == full_basis
             @test embedded * input_state == expected
+
+            inplace_state = copy(input_state)
+            @test apply!(inplace_state, 2, op) === inplace_state
+            @test inplace_state ≈ expected
         end
 
         for basis in (QuadPairBasis(2), QuadBlockBasis(2))
@@ -141,11 +145,19 @@
             embedded_two = embed(full_basis, [1, 3], op_two)
             transformed_13 = op_two * (s1 ⊗ s3)
             result = embedded_two * input_state
-            inplace_13 = apply!(input_state, op_two, [1, 3])
+            inplace_13 = apply!(input_state, [1, 3], op_two)
 
             @test ptrace(result, 2) == transformed_13
             @test ptrace(result, [1, 3]) == s2
             @test result ≈ inplace_13
+            @test inplace_13 === input_state
+
+            if basis isa QuadPairBasis
+                legacy_state = s1 ⊗ s2 ⊗ s3
+                legacy_13 = @test_deprecated apply!(legacy_state, op_two, [1, 3])
+                @test legacy_13 === legacy_state
+                @test legacy_13 ≈ result
+            end
         end
 
         @test_throws AssertionError embed(QuadPairBasis(3), [1, 2, 3, 4], displace(QuadPairBasis(1), α))


### PR DESCRIPTION
## Summary

- make `apply!(state, indices, operation)` the canonical indexed form for Gaussian unitaries
- add the same scalar/vector indexed API for Gaussian channels, allowing the QuantumSavory adapter to be removed
- preserve the former vector-unitary order through a deprecation wrapper
- bump Gabs to v1.3.8 and document the normalized API

## Validation

- affected TestItemRunner items: 140 passed
- full package suite: 1,245 passed, 4 expected broken
- documentation build: passed
- focused doctest with a fresh depot: 1 passed; warm rerun: 1 passed

The doctest harness preloads `StaticArrays` so cold dependency precompilation occurs before Documenter begins capturing output.