### PR TITLE
Require current TestItemRunner in downgrade tests

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -16,3 +16,6 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestItemRunner = "f8b46487-2199-4994-9208-9a1283c18c0a"
+
+[compat]
+TestItemRunner = "1.1.5"


### PR DESCRIPTION
## Summary

- set the test-environment TestItemRunner lower bound to 1.1.5, the latest General-registry release
- prevent minimum-dependency CI from selecting TestItemRunner 0.1.0, which lacks the filtered run_package_tests macro API used by this suite

## Validation

- Project.toml and test/Project.toml parse with Julia 1.12.6
- git diff --check
- hosted downgrade CI provides the locked minimum-version integration test