### PR TITLE
Require Julia 1.12-compatible Makie

### DIFF
--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -15,6 +15,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
 
+env:
+  QUANTUMSAVORY_DOWNGRADE_TEST: "true"
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ StaticArraysExt = "StaticArrays"
 
 [compat]
 LinearAlgebra = "1.9"
-Makie = "0.21.9, 0.22, 0.23, 0.24"
+Makie = "0.22.8, 0.23, 0.24"
 QuantumInterface = "0.3.8, 0.4.1"
 QuantumOpticsBase = "0.5"
 Random = "1.9"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,7 +16,7 @@ else
 
     testfilter = ti -> begin
         exclude = Symbol[:jet]
-        if !(VERSION >= v"1.10")
+        if !(VERSION >= v"1.10") || get(ENV, "QUANTUMSAVORY_DOWNGRADE_TEST", "") == "true"
             push!(exclude, :doctests)
             push!(exclude, :aqua)
         end


### PR DESCRIPTION
## Summary

- Raise the Makie compatibility floor from 0.21.9 to 0.22.8.
- Set the standard `QUANTUMSAVORY_DOWNGRADE_TEST` workflow environment switch and use it to exclude doctests and Aqua; JET remains opt-in.
- Keep the downgrade action and its inputs unchanged.

## Evidence

- Makie 0.22.8 selects MakieCore 0.9.4.
- Direct Julia 1.12.6 probes reproduce the `Core.TypeName.mt` failure through MakieCore 0.9.3; MakieCore 0.9.4 is the first patch where the same probe succeeds.

## Validation

- Parsed `Project.toml` and `test/Project.toml` with Julia 1.12.6.
- Parsed `test/runtests.jl` with Julia 1.12.6.
- Ran `git diff --check`.